### PR TITLE
Fix unexpected behavior when using a long certificate in command line.

### DIFF
--- a/util.c
+++ b/util.c
@@ -42,7 +42,7 @@ decode_file(char *file, struct hibacert **outcert, struct hibaext **outext) {
 	*outext = NULL;
 
 	if (strcmp(file, "-") != 0 && stat(file, &st) == -1) {
-		if (errno != ENOENT) {
+		if ((errno != ENOENT) && (errno != ENAMETOOLONG)) {
 			fatal("decode_file: %s: %s", file, strerror(errno));
 		}
 		debug2("decode_file: reading from command line");


### PR DESCRIPTION
Certificate passed via command line with a size larger than the expected
maximum filename size fail the stat syscall with ENAMETOOLONG rather
than ENOENT, which causes decode_file() to consider it as a filename
rather than inline.