### PR TITLE
Fix bad extension ID defines.

### DIFF
--- a/extensions.h
+++ b/extensions.h
@@ -26,8 +26,8 @@
 /*
  * HIBA Extensions IDs
  */
-#define HIBA_IDENTITY_ID "identity@hibassh.dev";
-#define HIBA_GRANT_ID "grant@hibassh.dev";
+#define HIBA_IDENTITY_ID "identity@hibassh.dev"
+#define HIBA_GRANT_ID "grant@hibassh.dev"
 
 /*
  * HIBA pre defined options


### PR DESCRIPTION
A bad copy-paste included a semi-colon at the end of the #define making
it impossible to use in some cases.