### PR TITLE
Hiba multiple grants

### DIFF
--- a/PROTOCOL.extensions
+++ b/PROTOCOL.extensions
@@ -46,9 +46,12 @@ The current version starts at 1, and so does minimum supported version.
 The rest of the data is a list of strings key1, value1, key2, value2, ...
 There must be exactly one value per key.
 
-The extension can be stored directly in the above described serialized binary
-format or optionally base64 encoded for simpler handling by shell tools and
-wrappers.
+The HIBA tools support the identity and grant extensions both in their raw
+serialized form as well as in base64 encoding.
+
+Warning: For attaching multiple grants to a single certificate one MUST use a
+comma separated list of base64 encoded grants (raw serialized extension only
+supports one grant per certificates).
 
 ## Extensions ID
 

--- a/hiba-ca.sh
+++ b/hiba-ca.sh
@@ -115,7 +115,7 @@ sign() {
 		T=""
 	fi
 
-	HIBAOPTS=()
+	HIBAEXTS=()
 	for ext in $HIBA; do
 		if [ ! -f "$dest/policy/$SUB/$ext" ]; then
 			echo "cannot find requested HIBA $EXT $ext"
@@ -125,8 +125,9 @@ sign() {
 			echo "user $ID not eligible for grant $ext"
 			return 1
 		fi
-		HIBAOPTS+=("-O" "extension:$EXT@hibassh.dev=$(cat $dest/policy/$SUB/$ext)")
+		HIBAEXTS+=("$(cat $dest/policy/$SUB/$ext)")
 	done
+	HIBAOPTS=("-O" extension:$EXT@hibassh.dev=$(IFS=,; echo "${HIBAEXTS[*]}"))
 
 	echo "== Signing $TYPE key ID $ID"
 	ssh-keygen -I "$ID" -s "$dest/ca" $T -n "$PRINCIPALS" -V "$VALIDITY" "${HIBAOPTS[@]}" "$@" "$TARGET.pub"

--- a/testdata/regression-test.sh
+++ b/testdata/regression-test.sh
@@ -24,10 +24,13 @@ SUCCESS
 START_TEST "hiba-ca.sh: create host identities"
 RUN ../hiba-ca.sh -d "$dest" -c -h -I host1 -- -N secret >> "$log"
 RUN ../hiba-ca.sh -d "$dest" -c -h -I host2 -- -N secret >> "$log"
+RUN ../hiba-ca.sh -d "$dest" -c -h -I host3 -- -N secret >> "$log"
 EXPECT_EXISTS "$dest/hosts/host1"
 EXPECT_EXISTS "$dest/hosts/host1.pub"
 EXPECT_EXISTS "$dest/hosts/host2"
 EXPECT_EXISTS "$dest/hosts/host2.pub"
+EXPECT_EXISTS "$dest/hosts/host3"
+EXPECT_EXISTS "$dest/hosts/host3.pub"
 SUCCESS
 #####
 
@@ -232,6 +235,15 @@ GOT=$(RUN ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
+SUCCESS
+#####
+
+START_TEST "hiba-chk: certificate: deny multiple identities"
+RUN ../hiba-ca.sh -d "$dest" -s -h -I host3 -V +30d -H owner:user1 -H owner:user2 -- -P secret &>> "$log"
+GOT=$(RUN ../hiba-chk -i "$dest/hosts/host3-cert.pub" -r root "$dest/users/user1-cert.pub")
+GOTCODE=$?
+EXPECT_EQ "" "$GOT"
+EXPECT_EQ 3 "$GOTCODE"
 SUCCESS
 #####
 

--- a/testdata/regression-test.sh
+++ b/testdata/regression-test.sh
@@ -42,8 +42,8 @@ SUCCESS
 #####
 
 START_TEST "hiba-gen: create identities"
-RUN ../hiba-gen -i -f "$dest/policy/identities/owner:user1" domain hiba.com owner user1 purpose production
-RUN ../hiba-gen -i -f "$dest/policy/identities/owner:user2" domain hiba.com owner user2 purpose testing
+RUN ../hiba-gen -i -f "$dest/policy/identities/owner:user1" domain hibassh.dev owner user1 purpose production
+RUN ../hiba-gen -i -f "$dest/policy/identities/owner:user2" domain hibassh.dev owner user2 purpose testing
 EXPECT_EXISTS "$dest/policy/identities/owner:user1"
 EXPECT_EXISTS "$dest/policy/identities/owner:user2"
 SUCCESS
@@ -51,13 +51,13 @@ SUCCESS
 
 START_TEST "hiba-gen: display identities"
 EXPECTED="identity@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] owner = 'user1'
  [2] purpose = 'production'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/policy/identities/owner:user1")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="identity@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] owner = 'user2'
  [2] purpose = 'testing'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/policy/identities/owner:user2")
@@ -66,12 +66,12 @@ SUCCESS
 #####
 
 START_TEST "hiba-gen: create grants"
-RUN ../hiba-gen -f "$dest/policy/grants/location:eu" domain hiba.com location EU &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/purpose:testing" domain hiba.com purpose testing role tester &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/lockedcmd" domain hiba.com options 'command="uname -a"' &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/badcmd" domain hiba.com options "command=uname -a" &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/all" domain hiba.com &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/disallowed" domain hiba.com &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/location:eu" domain hibassh.dev location EU &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/purpose:testing" domain hibassh.dev purpose testing role tester &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/lockedcmd" domain hibassh.dev options 'command="uname -a"' &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/badcmd" domain hibassh.dev options "command=uname -a" &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/all" domain hibassh.dev &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/disallowed" domain hibassh.dev &>> "$log"
 EXPECT_EXISTS "$dest/policy/grants/all"
 EXPECT_EXISTS "$dest/policy/grants/location:eu"
 EXPECT_EXISTS "$dest/policy/grants/purpose:testing"
@@ -107,18 +107,18 @@ SUCCESS
 
 START_TEST "hiba-gen: display grants"
 EXPECTED="grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] location = 'EU'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/policy/grants/location:eu")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] purpose = 'testing'
  [2] role = 'tester'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/policy/grants/purpose:testing")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'"
+ [0] domain = 'hibassh.dev'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/policy/grants/all")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
@@ -126,7 +126,7 @@ SUCCESS
 
 START_TEST "hiba-gen: grant in cmdline"
 EXPECTED="grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] location = 'EU'"
 GOT=$(RUN ../hiba-gen -d -f "$(cat $dest/policy/grants/location:eu)")
 EXPECT_EQ "$EXPECTED" "$GOT"
@@ -162,15 +162,15 @@ SUCCESS
 START_TEST "hiba-gen: display certificates"
 EXPECTED="certificate 'user1' contains 1 HIBA grants
 grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'"
+ [0] domain = 'hibassh.dev'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/users/user1-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="certificate 'user2' contains 2 HIBA grants
 grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] location = 'EU'
 grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'
+ [0] domain = 'hibassh.dev'
  [1] purpose = 'testing'
  [2] role = 'tester'"
 GOT=$(RUN ../hiba-gen -d -f "$dest/users/user2-cert.pub")
@@ -181,7 +181,7 @@ SUCCESS
 START_TEST "hiba-gen: certificate in cmdline"
 EXPECTED="certificate 'user1' contains 1 HIBA grants
 grant@hibassh.dev (v1):
- [0] domain = 'hiba.com'"
+ [0] domain = 'hibassh.dev'"
 GOT=$(RUN ../hiba-gen -d -f "$(cat $dest/users/user1-cert.pub)")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
@@ -244,7 +244,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: certificate: expired grant"
-RUN ../hiba-gen -f "$dest/policy/grants/all:1s" domain hiba.com validity 1 &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/all:1s" domain hibassh.dev validity 1 &>> "$log"
 RUN ../hiba-ca.sh -d "$dest" -p -I user1 -H all:1s &>> "$log"
 RUN ../hiba-ca.sh -d "$dest" -s -u -I user1 -H all:1s -- -P secret &>> "$log"
 sleep 2

--- a/util.c
+++ b/util.c
@@ -93,7 +93,7 @@ decode_file(char *file, struct hibacert **outcert, struct hibaext **outext) {
 
 			cert = hibacert_new();
 			if ((ret = hibacert_parse(cert, key)) < 0)
-				fatal("decode_file: failed to decode hiba grant extension from cert: %s", hiba_err(ret));
+				fatal("decode_file: failed to decode hiba extension from cert: %s", hiba_err(ret));
 			*outcert = cert;
 		} else {
 			// Maybe a HIBA extension
@@ -105,7 +105,7 @@ decode_file(char *file, struct hibacert **outcert, struct hibaext **outext) {
 
 			ext = hibaext_new();
 			if ((ret = hibaext_decode(ext, buf)) < 0)
-				fatal("decode_file: failed to decode hiba grant extension: %s", hiba_err(ret));
+				fatal("decode_file: failed to decode hiba extension: %s", hiba_err(ret));
 
 			*outext = ext;
 			sshbuf_free(buf);


### PR DESCRIPTION
Support for multiple HIBA grants attached to one certificate.

This pull request also includes: 
- testing for multiple identities (this must result in access denied)
- debug log rewording