### PR TITLE
Move remaining compilation options to configure.ac

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -4,8 +4,6 @@
 VERSION_INFO = -version-info $(SONAME_CURRENT):$(SONAME_REVISION):$(SONAME_AGE)
 ACLOCAL_AMFLAGS = -I m4
 
-AM_CPPFLAGS = -I@opensshdir@ -Wall -Wextra -Werror -Wno-attributes -Wno-unused-parameter -Wformat-security -Wuninitialized -D_FORTIFY_SOURCE=2 @hardening_cflags@
-AM_LDFLAGS = @hardening_ldflags@
 ARFLAGS = cr
 
 include_HEADERS = hiba.h extensions.h errors.h checks.h certificates.h
@@ -17,11 +15,11 @@ libhiba_la_LDFLAGS = $(VERSION_INFO)
 sbin_PROGRAMS = hiba-chk hiba-gen
 
 hiba_chk_SOURCES = hiba-chk.c util.c
-hiba_chk_LDADD = -L. -L@opensshdir@ -L@opensshdir@/openbsd-compat -lhiba -lssh -lopenbsd-compat
+hiba_chk_LDADD = -lhiba $(extra_LIBS)
 hiba_chk_DEPENDENCIES = libhiba.la
 
 hiba_gen_SOURCES = hiba-gen.c util.c
-hiba_gen_LDADD = -L. -L@opensshdir@ -L@opensshdir@/openbsd-compat -lhiba -lssh -lopenbsd-compat
+hiba_gen_LDADD = -lhiba $(extra_LIBS)
 hiba_gen_DEPENDENCIES = libhiba.la
 
 dist_sbin_SCRIPTS = hiba-ca.sh

--- a/configure.ac
+++ b/configure.ac
@@ -14,93 +14,222 @@ AC_PROG_CC([cc gcc clang])
 
 LT_INIT
 
+AM_INIT_AUTOMAKE([foreign no-dependencies])
+AM_SILENT_RULES([yes])
+
 # Values for SONAME. See -version-info for details.
 AC_SUBST(SONAME_CURRENT, 0)
 AC_SUBST(SONAME_REVISION, 0)
 AC_SUBST(SONAME_AGE, 0)
 
-save_cflags="$CFLAGS"
-save_ldflags="$LDFLAGS"
+save_CFLAGS="$CFLAGS"
+save_CPPFLAGS="$CPPFLAGS"
+save_LDFLAGS="$LDFLAGS"
+save_LIBS="$LIBS"
 
-# Check for required CFLAGS availability
+# Check for required CFLAGS & CPPFLAGS availability
+for f in -fstack-protector-strong -fstack-protector-all -fstack-protector; do
+	AC_MSG_CHECKING(whether $CC supports $f options)
+	CFLAGS="$CFLAGS $extra_CFLAGS $f -Werror"
+	LDFLAGS="$LDFLAGS $extra_LDFLAGS $f"
+	AC_LINK_IFELSE(
+		[AC_LANG_PROGRAM()], [
+			extra_LDFLAGS="$extra_LDFLAGS $f"
+			extra_CFLAGS="$extra_CFLAGS $f"
+			AC_MSG_RESULT([yes])
+			break
+		], [AC_MSG_RESULT([no])],
+	)
+	# Restore CFLAGS & LDFLAGS in the loop as options are exclusive.
+	LDFLAGS="$save_LDFLAGS"
+	CFLAGS="$save_CFLAGS"
+done
+
+for f in -fpie -fPIE -fpic -fPIC; do
+	AC_MSG_CHECKING(whether compiler supports $f)
+	CFLAGS="$CFLAGS $extra_CFLAGS $f -Werror"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM()], [
+			extra_CFLAGS="$extra_CFLAGS $f"
+			AC_MSG_RESULT([yes])
+			break
+		], [AC_MSG_RESULT([no])],
+	)
+	# Restore CFLAGS in the loop as options are exclusive.
+	CFLAGS="$save_CFLAGS"
+done
+
+for f in -Wall -Wextra -Werror -Wno-attributes -Wno-unused-parameter -Wformat-security -Wuninitialized; do
+	AC_MSG_CHECKING(whether $CC supports $f options)
+	CFLAGS="$CFLAGS $extra_CFLAGS $f"
+	AC_COMPILE_IFELSE(
+		[AC_LANG_PROGRAM()], [
+			extra_CFLAGS="$extra_CFLAGS $f"
+			AC_MSG_RESULT([yes])
+		], [AC_MSG_RESULT([no])],
+	)
+done
+CFLAGS="$save_CFLAGS"
+
+AC_MSG_CHECKING(whether preprocessor supports _FORTIFY_SOURCE)
+CPPFLAGS="$CPPFLAGS $extra_CPPFLAGS -D_FORTIFY_SOURCE=2"
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM()], [
+		extra_CPPFLAGS="$extra_CPPFLAGS -D_FORTIFY_SOURCE=2"
+		AC_MSG_RESULT([yes])
+	], [AC_MSG_RESULT([no])],
+)
+CPPFLAGS="$save_CPPFLAGS"
+
+AC_MSG_CHECKING(whether compiler supports no-strict-aliasing option)
+CFLAGS="$CFLAGS $extra_CFLAGS -fno-strict-aliasing -Werror"
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM()], [
+		extra_CFLAGS="$extra_CFLAGS -fno-strict-aliasing"
+		AC_MSG_RESULT([yes])
+	], [AC_MSG_RESULT([no])],
+)
+CFLAGS="$save_CFLAGS"
+
 AC_MSG_CHECKING(whether compiler supports hardening options)
-CFLAGS="$CFLAGS -Wa,--noexecstack"
+CFLAGS="$CFLAGS $extra_CFLAGS -Wa,--noexecstack -Werror"
 AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM()],
-  [hardening_cflags="$hardening_cflags -Wa,--noexecstack"; AC_MSG_RESULT([yes])],
-  [AC_MSG_RESULT([no])])
-CFLAGS="$save_cflags"
-
-AC_MSG_CHECKING(whether compiler supports ASLR)
-CFLAGS="$CFLAGS -fPIE"
-AC_COMPILE_IFELSE(
-  [AC_LANG_PROGRAM()],
-  [hardening_cflags="$hardening_cflags -fPIE"; AC_MSG_RESULT([yes])],
-  [AC_MSG_RESULT([no])])
-CFLAGS="$save_cflags"
-
-AC_SUBST([hardening_cflags], [$hardening_cflags])
+	[AC_LANG_PROGRAM()], [
+		extra_CFLAGS="$extra_CFLAGS -Wa,--noexecstack"
+		AC_MSG_RESULT([yes])
+	], [AC_MSG_RESULT([no])],
+)
+CFLAGS="$save_CFLAGS"
 
 # Check for required LDFLAGS availability
 AC_MSG_CHECKING(whether linker supports hardening options)
-LDFLAGS="$LDFLAGS -Wl,-z,relro,-z,now"
+LDFLAGS="$LDFLAGS $extra_LDFLAGS -Wl,-z,relro,-z,now"
 AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM()],
-  [hardening_ldflags="$hardening_ldflags -Wl,-z,relro,-z,now"; AC_MSG_RESULT([yes])],
-  [AC_MSG_RESULT([no])])
-LDFLAGS="$save_ldflags"
-
-AC_MSG_CHECKING(whether linker supports ASLR)
-LDFLAGS="$LDFLAGS -pie"
-AC_LINK_IFELSE(
-  [AC_LANG_PROGRAM()],
-  [hardening_ldflags="$hardening_ldflags -pie"; AC_MSG_RESULT([yes])],
-  [AC_MSG_RESULT([no])])
-LDFLAGS="$save_ldflags"
-
-AC_SUBST([hardening_ldflags], [$hardening_ldflags])
+	[AC_LANG_PROGRAM()], [
+		extra_LDFLAGS="$extra_LDFLAGS -Wl,-z,relro,-z,now"
+		AC_MSG_RESULT([yes])
+	], [AC_MSG_RESULT([no])],
+)
+LDFLAGS="$save_LDFLAGS"
 
 # Check for definition of max hostname length
-AC_CHECK_DECL([HOST_NAME_MAX], [
-  ], [
-    AC_DEFINE([HOST_NAME_MAX], [64], [Maximum supported hostname size if not already defined by OS.])
-  ], [#include <limits.h>])
+AC_CHECK_DECL(
+	[HOST_NAME_MAX], [], [AC_DEFINE([HOST_NAME_MAX], [64], [
+		Maximum supported hostname size if not already defined by OS.
+	])], [#include <limits.h>],
+)
 
-# Checks for openssh sources
-AC_ARG_WITH([opensshdir],
-  [AS_HELP_STRING([--with-opensshdir=DIR], [openssh source directory])],
-  [opensshdir=$withval],
-  [AC_MSG_ERROR([unable to find the openssh library])])
-AC_SUBST([opensshdir], [$opensshdir])
-
-# Check for openssh use of openssl
-AC_MSG_CHECKING(whether OpenSSH is configured with OpenSSL)
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
-    #include "$opensshdir/config.h"
-  ], [
-    #ifdef WITH_OPENSSL
-    #if WITH_OPENSSL != 0
-    #error 1
-    #endif
-    #endif
-  ])],
-  [need_openssl=false; AC_MSG_RESULT([no])],
-  [need_openssl=true; AC_MSG_RESULT([yes])])
+# Update flags.
+CFLAGS="$CFLAGS $extra_CFLAGS"
+CPPFLAGS="$CPPFLAGS $extra_CPPFLAGS"
+LDFLAGS="$LDFLAGS $extra_LDFLAGS"
 
 # We can't generate dynamic libraries on cygwin since openssh only builds a static libssh.
 case "$host" in
 *-*-cygwin*)
-  AS_VAR_IF([enable_shared], [yes],
-	    [AC_DISABLE_SHARED AC_MSG_WARN([Only static libraries can be buit using cygwin])],
-	    [])
+	AS_VAR_IF([enable_shared], [yes], [
+		AC_DISABLE_SHARED AC_MSG_WARN([Only static libraries can be buit using cygwin])
+		], [],
+	)
   ;;
 esac
 
-# Checks for libraries.
+# Checks for OpenSSH sources
+AC_ARG_WITH(
+	[opensshdir], [AS_HELP_STRING(
+		[--with-opensshdir=DIR], [OpenSSH source directory],
+	)], [opensshdir=$withval], [AC_MSG_ERROR([
+		unable to find the OpenSSH sources. Set --with-opensshdir=<path to OpenSSH sources>
+	])],
+)
+
+# Update flags with OpenSSH location
+CFLAGS="$CFLAGS -I$opensshdir"
+LDFLAGS="$LDFLAGS -L$opensshdir -L$opensshdir/openbsd-compat"
+
+# Check for OpenSSH use of OpenSSL
+AC_MSG_CHECKING(whether OpenSSH is configured with OpenSSL)
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM([
+		#include "$opensshdir/config.h"
+	], [
+		#ifdef WITH_OPENSSL
+		#if WITH_OPENSSL != 0
+		#error 1
+		#endif
+		#endif
+	])], [
+		need_openssl=false
+		AC_MSG_RESULT([no])
+	], [
+		need_openssl=true
+		AC_MSG_RESULT([yes])
+	],
+)
 AM_CONDITIONAL([NEED_OPENSSL], [test "x$need_openssl" = xtrue])
-AM_COND_IF([NEED_OPENSSL], [
-    AC_SEARCH_LIBS([RAND_add], [crypto], [], [AC_MSG_ERROR([unable to find the openssl library])])
-  ], [])
+
+# Checks for optional OpenSSL sources
+AC_ARG_WITH(
+	[openssldir], [AS_HELP_STRING(
+		[--with-openssldir=DIR], [OpenSSL source directory],
+	)], [openssldir=$withval], [],
+)
+AM_CONDITIONAL([OPENSSLDIR], [test "x$openssldir" != x])
+
+# Maybe checks for OpenSSL library.
+# First in openssldir if provided, then in sysroot.
+AM_COND_IF(
+	[NEED_OPENSSL], [
+		# Check whether user specified a custom location:
+		AC_MSG_CHECKING(whether custom OpenSSL folder is set)
+		AM_COND_IF(
+			[OPENSSLDIR], [
+				CFLAGS="$CFLAGS -I$openssldir/include"
+				LDFLAGS="$LDFLAGS -L$openssldir"
+				AC_MSG_RESULT(yes)
+			], [
+				AC_MSG_RESULT(no)
+			],
+		)
+		# In case of static libcrypto, we need explicit linking.
+		AC_MSG_CHECKING(whether OpenSSL requires explicit linking)
+		for l in '' '-ldl' '-lpthread' '-ldl -lpthread'; do
+			LIBS="-lcrypto $l"
+			AC_LINK_IFELSE(
+				[AC_LANG_CALL([], [RSA_new])], [
+					libcrypto_LIBS=$l
+					break
+				], [],
+			)
+		done
+		LIBS="$save_LIBS"
+
+		if test "x$libcrypto_LIBS" = x; then
+			AC_MSG_RESULT(no)
+		else
+			AC_MSG_RESULT($libcrypto_LIBS)
+		fi
+
+		# Add the OpenSSL library.
+		AC_SEARCH_LIBS(
+			[RSA_new], [crypto], [], [
+				AC_MSG_ERROR([unable to find a working OpenSSL library])
+			], [$libcrypto_LIBS])
+		LIBS="$LIBS $libcrypto_LIBS"
+	], [],
+)
+
+# Checks for OpenBSD compat library (part of OpenSSH).
+AC_SEARCH_LIBS([ssh_get_progname], [openbsd-compat], [], [
+	AC_MSG_ERROR([/!\ Make sure to configure and build OpenSSH before HIBA.])],
+)
+
+# Checks for OpenSSH compat library.
+AC_SEARCH_LIBS([sshbuf_new], [ssh], [], [
+	AC_MSG_ERROR([/!\ Make sure to configure and build OpenSSH before HIBA.])],
+)
+AC_SUBST([extra_LIBS], [$LIBS])
+LIBS="$save_LIBS"
 
 # Checks for header files.
 AC_CHECK_HEADERS([inttypes.h limits.h stdint.h stdlib.h string.h unistd.h])
@@ -112,10 +241,19 @@ AC_TYPE_SIZE_T
 # Checks for library functions.
 AC_CHECK_FUNCS([gethostname memset strdup strerror strspn strtol])
 
-AM_INIT_AUTOMAKE([foreign no-dependencies])
-AM_SILENT_RULES([yes])
-
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT
-AC_MSG_NOTICE([/!\ Make sure to configure and build OpenSSH before HIBA.])
 
+# Print configuration summary
+echo ""
+echo "MIBA has been configure with the following options:"
+echo ""
+echo "              Host: $host"
+echo "          Compiler: $CC"
+echo "    Compiler flags: $CFLAGS"
+echo "Preprocessor flags: $CPPFLAGS"
+echo "            Linker: $LD"
+echo "      Linker flags: $LDFLAGS"
+echo "         Libraries: $LIBS $extra_LIBS"
+echo "    Shared library: $enable_shared"
+echo "    Static library: $enable_static"


### PR DESCRIPTION
This allows for more complete checks and better compatibility with
various setups.