### PR TITLE
build: Add bootstrap.sh for hiba

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,12 +9,12 @@ the compilation will fail. For instructions compiling OpenSSH, refer to the
 [INSTALL](https://github.com/openssh/openssh-portable/blob/master/INSTALL) file
 inside OpenSSH's sources.
 
-To compile HIBA, run the `./autogen.sh` followed by `./configure` using
+To compile HIBA, run the `./bootstrap.sh` followed by `./configure` using
 the `--with-opensshdir` pointing at the root of the OpenSSH sources, and
 finally, run `make`.
 
 ```
-$ ./autogen.sh 
+$ ./bootstrap.sh
 $ ./configure --with-opensshdir=/path/to/openssh/sources/ --prefix=/usr/
 $ make
 ```

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,5 +1,0 @@
-#!/bin/sh
-
-set -x -e
-mkdir -p m4
-autoreconf -fvi

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+AUTOCONF_FILES="Makefile.in aclocal.m4 ar-lib autom4te.cache compile \
+        config.guess config.h.in config.sub configure depcomp install-sh \
+        ltmain.sh missing *libtool test-driver"
+
+case $1 in
+    clean)
+        test -f Makefile && make maintainer-clean
+        for file in ${AUTOCONF_FILES}; do
+            find . -name "$file" -print0 | xargs -0 -r rm -rf
+        done
+        exit 0
+        ;;
+esac
+
+autoreconf -fvi
+# shellcheck disable=SC2016
+echo 'Run "./configure ${CONFIGURE_FLAGS} && make"'

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,17 +1,19 @@
 #!/bin/sh
 
 AUTOCONF_FILES="Makefile.in aclocal.m4 ar-lib autom4te.cache compile \
-        config.guess config.h.in config.sub configure depcomp install-sh \
-        ltmain.sh missing *libtool test-driver"
+  config.guess config.h.in config.sub configure depcomp install-sh \
+  ltmain.sh missing *libtool test-driver"
 
 case $1 in
-    clean)
-        test -f Makefile && make maintainer-clean
-        for file in ${AUTOCONF_FILES}; do
-            find . -name "$file" -print0 | xargs -0 -r rm -rf
-        done
-        exit 0
-        ;;
+  # Cleanup autotool files. The bootstrap.sh will still work fine without
+  # cleanup beforehand.
+  clean)
+    test -f Makefile && make maintainer-clean
+      for file in ${AUTOCONF_FILES}; do
+        find . -name "$file" -print0 | xargs -0 -r rm -rf
+      done
+      exit 0
+      ;;
 esac
 
 autoreconf -fvi


### PR DESCRIPTION
This script is needed for bitbake to build it properly in
https://gbmc-review.googlesource.com/c/meta-gbmc-staging/+/2001

Tested:
Able to build hiba after running bootstrap.sh
```
./bootstrap.sh
autoreconf: export WARNINGS=
autoreconf: Entering directory '.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: libtoolize --copy --force
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
autoreconf: configure.ac: not using Intltool
autoreconf: configure.ac: not using Gtkdoc
autoreconf: running: aclocal --force -I m4
autoreconf: running: /usr/bin/autoconf --force
autoreconf: running: /usr/bin/autoheader --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:13: installing './compile'
configure.ac:17: installing './missing'
autoreconf: Leaving directory '.'
Run "./configure ${CONFIGURE_FLAGS} && make"
```

Signed-off-by: Willy Tu <wltu@google.com>