### PR TITLE
Expose util.c for external project

### DIFF
--- a/certificates.c
+++ b/certificates.c
@@ -17,6 +17,14 @@
 #include "ssherr.h"
 #include "xmalloc.h"
 
+/* OpenSSH's sshkey_sign function depends on a sshsk_sign function provided by
+ * the caller. HIBA doesn't use this symbols but it ends up implicitly imported
+ * along with the sshkey_read function. To work around that and make the linker
+ * happy, we declare a dummy sshsk_sign().
+ */
+int
+sshsk_sign() { abort(); return 0; }
+
 struct hibacert {
 	struct sshkey *key;
 	struct hibaext **exts;

--- a/util.c
+++ b/util.c
@@ -22,14 +22,6 @@
 #include "sshkey.h"
 #include "xmalloc.h"
 
-/* OpenSSH's sshkey_sign function depends on a sshsk_sign function provided by
- * the caller. HIBA doesn't use this symbols but it ends up implicitly imported
- * along with the sshkey_read function. To work around that and make the linker
- * happy, we declare a dummy sshsk_sign().
- */
-int
-sshsk_sign() { abort(); return 0; }
-
 void
 decode_file(char *file, struct hibacert **outcert, struct hibaext **outext) {
 	FILE *f = NULL;


### PR DESCRIPTION
The issue with `sshsk_sign` can happen if projects wants to include
libhiba.so. Include sshsk_sign in libhiba.so directly for external
projects to depend on instead of having them work around it individually

Signed-off-by: Willy Tu <wltu@google.com>