### PR TITLE
Make the dummy sshsk_sign symbol weak.

### DIFF
--- a/certificates.c
+++ b/certificates.c
@@ -20,9 +20,13 @@
 /* OpenSSH's sshkey_sign function depends on a sshsk_sign function provided by
  * the caller. HIBA doesn't use this symbols but it ends up implicitly imported
  * along with the sshkey_read function. To work around that and make the linker
- * happy, we declare a dummy sshsk_sign().
+ * happy, we declare a weak dummy sshsk_sign().
  */
+#ifndef __CYGWIN__
+int  __attribute__((weak))
+#else // __CYGWIN__
 int
+#endif // __CYGWIN__
 sshsk_sign() { abort(); return 0; }
 
 struct hibacert {


### PR DESCRIPTION
https://github.com/openssh/openssh-portable/pull/358 tries to properly fix the missing `sshsk_sign` symbol in OpenSSH.

Once that pull request is merged, HIBA might fail to build against newer versions of OpenSSH since the symbol will now be duplicated (depending on compilers). As we can't easily declare a clean cut-off, making the symbol weak will allow for a smoother transition.