### PR TITLE
Fix missing extension initialization.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -228,9 +228,11 @@ hibachk_query(const struct hibaext *identity, const struct hibaext *grant, const
 	struct hibaext *result = NULL;
 
 	result = hibaext_new();
+	hibaext_init(result, HIBA_GRANT_EXT);
 
 	// Test all keys from the grant against the identity:
 	for (i = 0; i < hibaext_pairs_len(grant); ++i) {
+		int skip = 0;
 		char *key;
 		char *value;
 
@@ -239,10 +241,10 @@ hibachk_query(const struct hibaext *identity, const struct hibaext *grant, const
 			goto err;
 		} else if (strcmp(key, HIBA_KEY_OPTIONS) == 0) {
 			debug2("hibachk_query: skipping 'options' key");
-			continue;
+			skip = 1;
 		} else if (strcmp(key, HIBA_KEY_VALIDITY) == 0) {
 			debug2("hibachk_query: skipping 'validity' key: already verified");
-			continue;
+			skip = 1;
 		} else if (strcmp(key, HIBA_KEY_HOSTNAME) == 0) {
 			debug2("hibachk_query: testing hostname %s", value);
 			ret = strcmp(hostname, value);
@@ -254,7 +256,9 @@ hibachk_query(const struct hibaext *identity, const struct hibaext *grant, const
 			ret = hibachk_keycmp(identity, key, value);
 		}
 
-		hibachk_register_result(result, key, ret);
+		if (!skip) {
+			hibachk_register_result(result, key, ret);
+		}
 		free(key);
 		free(value);
 	}

--- a/testdata/regression-test.sh
+++ b/testdata/regression-test.sh
@@ -76,11 +76,13 @@ RUN ../hiba-gen -f "$dest/policy/grants/lockedcmd" domain hibassh.dev options 'c
 RUN ../hiba-gen -f "$dest/policy/grants/badcmd" domain hibassh.dev options "command=uname -a" &>> "$log"
 RUN ../hiba-gen -f "$dest/policy/grants/all" domain hibassh.dev &>> "$log"
 RUN ../hiba-gen -f "$dest/policy/grants/disallowed" domain hibassh.dev &>> "$log"
+RUN ../hiba-gen -f "$dest/policy/grants/2roles" domain hibassh.dev role user1 role user2 &>> "$log"
 RUN ../hiba-gen -f "$dest/policy/grants/selfonly" domain hibassh.dev role @PRINCIPALS &>> "$log"
 EXPECT_EXISTS "$dest/policy/grants/all"
 EXPECT_EXISTS "$dest/policy/grants/location:eu"
 EXPECT_EXISTS "$dest/policy/grants/purpose:testing"
 EXPECT_EXISTS "$dest/policy/grants/disallowed"
+EXPECT_EXISTS "$dest/policy/grants/2roles"
 EXPECT_EXISTS "$dest/policy/grants/selfonly"
 EXPECT_NOT_EXISTS "$dest/policy/grants/badcmd"
 SUCCESS
@@ -236,6 +238,18 @@ GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r root -p user1 
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 46 "$GOTCODE"
+SUCCESS
+#####
+
+START_TEST "hiba-chk: extension: allow when multiple roles"
+GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user1 -p user1 "$dest/policy/grants/2roles")
+GOTCODE=$?
+EXPECT_EQ "user1" "$GOT"
+EXPECT_EQ 0 "$GOTCODE"
+GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user2 -p user1 "$dest/policy/grants/2roles")
+GOTCODE=$?
+EXPECT_EQ "user1" "$GOT"
+EXPECT_EQ 0 "$GOTCODE"
 SUCCESS
 #####
 


### PR DESCRIPTION
The authorizatyion logic relies on an internal grant extension for merging the result of similar keys (OR semantic). Since this extension was allocated but not initialized, the merging logic failed.

This results in repeated keys to be handled as last one wins.