### PR TITLE
Switch to using -ansi for compilation.

### DIFF
--- a/certificates.c
+++ b/certificates.c
@@ -20,13 +20,12 @@
 /* OpenSSH's sshkey_sign function depends on a sshsk_sign function provided by
  * the caller. HIBA doesn't use this symbols but it ends up implicitly imported
  * along with the sshkey_read function. To work around that and make the linker
- * happy, we declare a weak dummy sshsk_sign().
- */
+ * happy, we declare a weak dummy sshsk_sign(). */
 #ifndef __CYGWIN__
 int  __attribute__((weak))
-#else // __CYGWIN__
+#else /* __CYGWIN__ */
 int
-#endif // __CYGWIN__
+#endif /* __CYGWIN__ */
 sshsk_sign() { abort(); return 0; }
 
 struct hibacert {
@@ -62,8 +61,8 @@ hibacert_from_ext(struct hibacert *cert, struct hibaext *ext,
 	if (cert == NULL || ext == NULL)
 		return HIBA_BAD_PARAMS;
 
-	// Create a dummy SSH certificate to support standalone HIBA extensions.
-	// The KEY_RSA_CERT type is picked at random and doesn't matter.
+	/* Create a dummy SSH certificate to support standalone HIBA extensions.
+	 * The KEY_RSA_CERT type is picked at random and doesn't matter. */
 	cert->key = sshkey_new(KEY_RSA_CERT);
 	cert->key->cert->serial = serial;
 	cert->key->cert->valid_after = validity;
@@ -101,8 +100,8 @@ hibacert_load_extensions(struct hibacert *cert, struct sshbuf *extensions) {
 	while (i < len) {
 		int extension_len = 0;
 		if ((i == 0) && (magic == HIBA_MAGIC)) {
-			// there is a chance we have a single extension in
-			// the raw serialized format.
+			/* there is a chance we have a single extension in
+			 * the raw serialized format. */
 			extension_len = len;
 			i = len - 1;
 		} else if (data[i] == ',') {
@@ -148,7 +147,7 @@ hibacert_parse(struct hibacert *cert, struct sshkey *key) {
 	if ((extensions = sshbuf_fromb(cert->key->cert->extensions)) == NULL)
 		return HIBA_INTERNAL_ERROR;
 
-	// Look for HIBA extensions
+	/* Look for HIBA extensions. */
 	debug2("hibacert_parse: looking for HIBA extensions for cert type %d", cert->key->cert->type);
 	if (cert->key->cert->type == SSH2_CERT_TYPE_HOST) {
 		expected_hiba_ext = HIBA_IDENTITY_ID;

--- a/certificates.h
+++ b/certificates.h
@@ -43,6 +43,6 @@ int hibacert_hibaexts(const struct hibacert *cert, struct hibaext ***exts,
 int hibacert_from_ext(struct hibacert *cert, struct hibaext *ext,
                       const char *principal, u_int64_t validity,
                       u_int64_t serial);
-#endif  // HIBA_INTERNAL
+#endif  /* HIBA_INTERNAL */
 
-#endif  // _CERTIFICATES_H
+#endif  /* _CERTIFICATES_H */

--- a/checks.h
+++ b/checks.h
@@ -45,4 +45,4 @@ struct hibaenv *hibaenv_from_host(const struct hibacert *host, const struct hiba
 /* Destructor for hibaenv. */
 void hibaenv_free(struct hibaenv *env);
 
-#endif  // _CHECKS_H
+#endif  /* _CHECKS_H */

--- a/configure.ac
+++ b/configure.ac
@@ -59,7 +59,7 @@ for f in -fpie -fPIE -fpic -fPIC; do
 	CFLAGS="$save_CFLAGS"
 done
 
-for f in -Wall -Wextra -Werror -Wno-attributes -Wno-unused-parameter -Wformat-security -Wuninitialized; do
+for f in -ansi -Wall -Wextra -Werror -Wno-attributes -Wno-unused-parameter -Wformat-security -Wuninitialized; do
 	AC_MSG_CHECKING(whether $CC supports $f options)
 	CFLAGS="$CFLAGS $extra_CFLAGS $f"
 	AC_COMPILE_IFELSE(
@@ -70,6 +70,16 @@ for f in -Wall -Wextra -Werror -Wno-attributes -Wno-unused-parameter -Wformat-se
 	)
 done
 CFLAGS="$save_CFLAGS"
+
+AC_MSG_CHECKING(whether preprocessor supports _DEFAULT_SOURCE)
+CPPFLAGS="$CPPFLAGS $extra_CPPFLAGS -D_DEFAULT_SOURCE"
+AC_COMPILE_IFELSE(
+	[AC_LANG_PROGRAM()], [
+		extra_CPPFLAGS="$extra_CPPFLAGS -D_DEFAULT_SOURCE"
+		AC_MSG_RESULT([yes])
+	], [AC_MSG_ERROR([no])],
+)
+CPPFLAGS="$save_CPPFLAGS"
 
 AC_MSG_CHECKING(whether preprocessor supports _FORTIFY_SOURCE)
 CPPFLAGS="$CPPFLAGS $extra_CPPFLAGS -D_FORTIFY_SOURCE=2"
@@ -232,7 +242,7 @@ AC_SUBST([extra_LIBS], [$LIBS])
 LIBS="$save_LIBS"
 
 # Checks for header files.
-AC_CHECK_HEADERS([inttypes.h limits.h stdint.h stdlib.h string.h unistd.h])
+AC_CHECK_HEADERS([inttypes.h limits.h stdint.h stdlib.h string.h sys/types.h unistd.h])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_C_INLINE

--- a/errors.h
+++ b/errors.h
@@ -12,7 +12,7 @@
 
 #define HIBA_OK 0
 
-// Generic error codes
+/* Generic error codes. */
 #define HIBA_INVALID_EXT -1
 #define HIBA_BAD_VERSION -2
 #define HIBA_BAD_PARAMS -3
@@ -22,7 +22,7 @@
 #define HIBA_INTERNAL_ERROR -7
 #define HIBA_INVALID_GRL -8
 
-// Extensions sanity checks diagnostics
+/* Extensions sanity checks diagnostics. */
 #define HIBA_EXT_NODOMAIN -20
 #define HIBA_GRANT_BADVALIDITY -21
 #define HIBA_PAIRS_TOOMANY -22
@@ -30,7 +30,7 @@
 #define HIBA_UNEXPECTED_KEY -24
 #define HIBA_GRANT_BADOPTIONS -25
 
-// Check results
+/* Check results. */
 #define HIBA_CHECK_NOKEY -40
 #define HIBA_CHECK_BADVERSION -41
 #define HIBA_CHECK_EXPIRED -42
@@ -44,4 +44,4 @@
 /* Return human readable error messages. */
 const char *hiba_err(int err);
 
-#endif  // _ERRORS_H
+#endif  /* _ERRORS_H */

--- a/extensions.c
+++ b/extensions.c
@@ -140,7 +140,7 @@ hibaext_encode(const struct hibaext *ext, struct sshbuf *blob) {
 	if ((ret = hibaext_sanity_check(ext)) != 0)
 		return ret;
 
-	// Pre-calculate size
+	/* Pre-calculate size. */
 	pair = &ext->pairs;
 	while(pair->next != NULL && count < ext->npairs) {
 		pair = pair->next;
@@ -156,7 +156,7 @@ hibaext_encode(const struct hibaext *ext, struct sshbuf *blob) {
 		goto err;
 	}
 
-	// Construct the sshbuf
+	/* Construct the sshbuf. */
 	debug3("hibaext_encode: encoding header");
 	if ((ret = sshbuf_put_u32(d, HIBA_MAGIC)) != 0) {
 		debug3("hibaext_encode: sshbuf_put_u32 returned %d: %s", ret, ssh_err(ret));
@@ -255,7 +255,7 @@ hibaext_free(struct hibaext *ext) {
 	free(ext);
 }
 
-inline u_int32_t
+__inline__ u_int32_t
 hibaext_type(const struct hibaext *ext) {
 	if (ext == NULL)
 		return HIBA_UNKNOWN_EXT;

--- a/extensions.h
+++ b/extensions.h
@@ -12,26 +12,18 @@
 
 #include "sshbuf.h"
 
-/*
- * HIBA extensions magic header
- */
+/* HIBA extensions magic header. */
 #define HIBA_MAGIC 0x48494241
 
-/*
- * HIBA extension types
- */
+/* HIBA extension types. */
 #define HIBA_IDENTITY_EXT 'i'
 #define HIBA_GRANT_EXT 'g'
 
-/*
- * HIBA Extensions IDs
- */
+/* HIBA Extensions IDs. */
 #define HIBA_IDENTITY_ID "identity@hibassh.dev"
 #define HIBA_GRANT_ID "grant@hibassh.dev"
 
-/*
- * HIBA pre defined options
- */
+/* HIBA pre defined options. */
 #define HIBA_KEY_DOMAIN "domain"
 #define HIBA_KEY_ROLE "role"
 #define HIBA_KEY_VALIDITY "validity"
@@ -115,4 +107,4 @@ int hibaext_add_pair(struct hibaext *ext, const char *key, const char *value);
 int hibaext_update_pair(struct hibaext *ext, const char *key,
                         const char *value);
 
-#endif // _EXTENSIONS_H
+#endif /* _EXTENSIONS_H */

--- a/hiba-chk.c
+++ b/hiba-chk.c
@@ -82,7 +82,7 @@ main(int argc, char **argv) {
 	struct hibaext *grant;
 	char *__progname = ssh_get_progname(argv[0]);
 
-	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null */
+	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null. */
 	sanitise_stdfd();
 
 	while ((opt = getopt(argc, argv, "vr:i:g:p:")) != -1) {
@@ -147,31 +147,32 @@ main(int argc, char **argv) {
 
 		if (host == NULL) {
 			host = hibacert_new();
-			// If we got a HIBA identity extension with no SSH
-			// certificate, we must emulate the certificate serial
-			// and issued time. We do this with the following
-			// values: hardcoded certificate serial (causes
-			// revocations to be all or nothing), and issued on the
-			// UNIX epoch.
+			/* If we got a HIBA identity extension with no SSH
+			 * certificate, we must emulate the certificate serial
+			 * and issued time. We do this with the following
+			 * values: hardcoded certificate serial (causes
+			 * revocations to be all or nothing), and issued on the
+			 * UNIX epoch. */
 			if ((ret = hibacert_from_ext(host, identity, principal, 0, HOST_DEFAULT_CERT_SERIAL)) < 0)
 				fatal("%s: creating host certificate from extension: %s", __progname, hiba_err(ret));
 			identity = NULL;
 		}
 		if (user == NULL) {
 			user = hibacert_new();
-			// If we got a HIBA grant extension with no SSH
-			// certificate, we must emulate the certificate serial
-			// and issued time. We do this with the following
-			// values: hardcoded certificate serial (causes
-			// revocations to be all or nothing), and issued now
-			// (causes validity to always pass).
+			/* If we got a HIBA grant extension with no SSH
+			 * certificate, we must emulate the certificate serial
+			 * and issued time. We do this with the following
+			 * values: hardcoded certificate serial (causes
+			 * revocations to be all or nothing), and issued now
+			 * (causes validity to always pass). */
 			if ((ret = hibacert_from_ext(user, grant, principal, time(NULL), USER_DEFAULT_CERT_SERIAL)) < 0)
 				fatal("%s: creating user certificate from extension: %s", __progname, hiba_err(ret));
 			grant = NULL;
 		}
 
 		if (grl_file != NULL) {
-			// If a GRL file was specified but the content is not found, we fail closed.
+			/* If a GRL file was specified but the content is not
+                         * found, we fail closed. */
 			if (grl_data == NULL) {
 				fatal("%s:  cannot read GRL file %s", __progname, grl_file);
 			}

--- a/hiba-gen.c
+++ b/hiba-gen.c
@@ -127,7 +127,7 @@ main(int argc, char **argv) {
 
 	char *__progname = ssh_get_progname(argv[0]);
 
-	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null */
+	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null. */
 	sanitise_stdfd();
 
 	if (argc <= 1)

--- a/hiba-grl.c
+++ b/hiba-grl.c
@@ -44,7 +44,7 @@ static void do_revoke(struct hibagrl *grl, u_int64_t *serial, char *file, int ar
 		fatal("do_revoke: missing grant IDs");
 	}
 
-	// perform revocations
+	/* perform revocations. */
 	for (i = 0; i < argc; ++i) {
 		char *err;
 		u_int64_t id = strtoul(argv[i], &err, 0);
@@ -53,7 +53,7 @@ static void do_revoke(struct hibagrl *grl, u_int64_t *serial, char *file, int ar
 		hibagrl_revoke_grant(grl, *serial, id, id);
 	}
 
-	// Write back
+	/* Write back. */
 	blob = sshbuf_new();
 	if ((ret = hibagrl_encode(grl, blob)) < 0) {
 		fatal("do_revoke: failed to serialize GRL: %s", hiba_err(ret));
@@ -77,7 +77,7 @@ static int do_test(struct hibagrl *grl, u_int64_t *serial, int argc, char **argv
 		fatal("do_test: missing grant IDs");
 	}
 
-	// Test
+	/* Test. */
 	for (i = 0; i < argc; ++i) {
 		int ret;
 		char *err;

--- a/hiba.h
+++ b/hiba.h
@@ -10,7 +10,7 @@
 
 #ifdef __cplusplus
 extern "C" {
-#endif  // __cplusplus
+#endif  /* __cplusplus */
 
 #include "certificates.h"
 #include "checks.h"
@@ -20,6 +20,6 @@ extern "C" {
 
 #ifdef __cplusplus
 }
-#endif  // __cplusplus
+#endif  /* __cplusplus */
 
-#endif  // _HIBA_H
+#endif  /* _HIBA_H */

--- a/revocations.h
+++ b/revocations.h
@@ -83,6 +83,6 @@ u_int64_t hibagrl_serials_count(const struct hibagrl *grl);
 /* Dump the content of a GRL object into human readable format.
  * The serial parameter can be used to filter for one serial if not NULL. */
 int hibagrl_dump_content(const struct hibagrl *grl, u_int64_t *serial, FILE *f);
-#endif // HIBA_INTERNAL
+#endif /* HIBA_INTERNAL */
 
-#endif  // _REVOCATIONS_H
+#endif  /* _REVOCATIONS_H */

--- a/util.c
+++ b/util.c
@@ -83,7 +83,7 @@ decode_file(char *file, struct hibacert **outcert, struct hibaext **outext) {
 		}
 
 		if (ret == 0) {
-			// Maybe a certificate
+			/* Maybe a certificate. */
 			struct hibacert *cert;
 
 			if (!sshkey_is_cert(key))
@@ -94,7 +94,7 @@ decode_file(char *file, struct hibacert **outcert, struct hibaext **outext) {
 				fatal("decode_file: failed to decode hiba extension from cert: %s", hiba_err(ret));
 			*outcert = cert;
 		} else {
-			// Maybe a HIBA extension
+			/* Maybe a HIBA extension. */
 			struct sshbuf *buf = sshbuf_from(cp, linesize);
 			struct hibaext *ext = NULL;
 

--- a/util.h
+++ b/util.h
@@ -34,4 +34,4 @@ void open_grl(const char *file, unsigned char **ptr, u_int64_t *sz, int *mmapped
 /* Release resources allocated by open_grl. */
 void close_grl(unsigned char *ptr, u_int64_t sz, int mmapped);
 
-#endif  // _UTIL_H
+#endif  /* _UTIL_H */


### PR DESCRIPTION
This fixes some duplicate symbol compilation errors on darwin toolchains caused by inlined libc functions.

This change does:
- convert all // comments to /**/ comments
- replace explicit `inline` with `__inline__`
- add `-ansi` to CFLAGS
- fix missing definitions for u_char and u_int used by OpenSSH