### PR TITLE
Add support for static code checking while running regression tests.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -144,3 +144,14 @@ provided. This script will:
 * Sign the certificates with extensions
 * Generate ssh client and server configs
 * Start 2 local sshd servers (simulating 2 different hosts)
+
+A set of regression tests is also provided in `testdata/regression-test.sh`. It
+supports wrapping all hiba-(chk|gen|grl) calls by setting the RUN_UNDER shell
+variable to the wrapping command itself. Example:
+
+```
+$ RUN_UNDER="valgrind --error-limit=no --trace-children=yes --show-leak-kinds=all --leak-check=full" testdata/regression-test.sh
+```
+
+Note: when using `RUN_UNDER`, make sure to configure HIBA with `--disable-shared`
+to avoid testing libtool's shell wrappers.

--- a/hiba-gen.c
+++ b/hiba-gen.c
@@ -125,7 +125,7 @@ main(int argc, char **argv) {
 	int type = HIBA_GRANT_EXT;
 	char *file = NULL;
 
-	char *__progname = ssh_get_progname(argv[0]);
+	char *__progname;
 
 	/* Ensure that fds 0, 1 and 2 are open or directed to /dev/null. */
 	sanitise_stdfd();

--- a/testdata/regression-test.sh
+++ b/testdata/regression-test.sh
@@ -46,8 +46,8 @@ SUCCESS
 #####
 
 START_TEST "hiba-gen: create identities"
-RUN ../hiba-gen -i -f "$dest/policy/identities/owner:user1" domain hibassh.dev owner user1 purpose production
-RUN ../hiba-gen -i -f "$dest/policy/identities/owner:user2" domain hibassh.dev owner user2 purpose testing
+RUN_T ../hiba-gen -i -f "$dest/policy/identities/owner:user1" domain hibassh.dev owner user1 purpose production
+RUN_T ../hiba-gen -i -f "$dest/policy/identities/owner:user2" domain hibassh.dev owner user2 purpose testing
 EXPECT_EXISTS "$dest/policy/identities/owner:user1"
 EXPECT_EXISTS "$dest/policy/identities/owner:user2"
 SUCCESS
@@ -58,26 +58,26 @@ EXPECTED="identity@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] owner = 'user1'
  [2] purpose = 'production'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/policy/identities/owner:user1")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/policy/identities/owner:user1")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="identity@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] owner = 'user2'
  [2] purpose = 'testing'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/policy/identities/owner:user2")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/policy/identities/owner:user2")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
 #####
 
 START_TEST "hiba-gen: create grants"
-RUN ../hiba-gen -f "$dest/policy/grants/location:eu" domain hibassh.dev location EU &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/purpose:testing" domain hibassh.dev purpose testing role tester &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/lockedcmd" domain hibassh.dev options 'command="uname -a"' &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/badcmd" domain hibassh.dev options "command=uname -a" &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/all" domain hibassh.dev &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/disallowed" domain hibassh.dev &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/2roles" domain hibassh.dev role user1 role user2 &>> "$log"
-RUN ../hiba-gen -f "$dest/policy/grants/selfonly" domain hibassh.dev role @PRINCIPALS &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/location:eu" domain hibassh.dev location EU &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/purpose:testing" domain hibassh.dev purpose testing role tester &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/lockedcmd" domain hibassh.dev options 'command="uname -a"' &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/badcmd" domain hibassh.dev options "command=uname -a" &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/all" domain hibassh.dev &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/disallowed" domain hibassh.dev &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/2roles" domain hibassh.dev role user1 role user2 &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/selfonly" domain hibassh.dev role @PRINCIPALS &>> "$log"
 EXPECT_EXISTS "$dest/policy/grants/all"
 EXPECT_EXISTS "$dest/policy/grants/location:eu"
 EXPECT_EXISTS "$dest/policy/grants/purpose:testing"
@@ -117,17 +117,17 @@ START_TEST "hiba-gen: display grants"
 EXPECTED="grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] location = 'EU'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/policy/grants/location:eu")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/policy/grants/location:eu")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] purpose = 'testing'
  [2] role = 'tester'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/policy/grants/purpose:testing")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/policy/grants/purpose:testing")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/policy/grants/all")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/policy/grants/all")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
 #####
@@ -136,7 +136,7 @@ START_TEST "hiba-gen: grant in cmdline"
 EXPECTED="grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] location = 'EU'"
-GOT=$(RUN ../hiba-gen -d -f "$(cat $dest/policy/grants/location:eu)")
+GOT=$(RUN_T ../hiba-gen -d -f "$(cat $dest/policy/grants/location:eu)")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
 #####
@@ -147,12 +147,12 @@ EXPECTED="certificate 'test' (1 principal) contains 1 HIBA grant
 grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] id = '1'"
-VERBOSE='' RUN ../generate-test-certs "$SINGLERAW" "$tmpdir/user-singleraw-cert.pub"
-GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-singleraw-cert.pub")
+RUN ../generate-test-certs "$SINGLERAW" "$tmpdir/user-singleraw-cert.pub"
+GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-singleraw-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 if [[ -n "$WITH_EXTENSION_COMPRESSION" ]]; then
-	VERBOSE='' RUN ../generate-test-certs "$SINGLERAWZ" "$tmpdir/user-singlerawz-cert.pub"
-	GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-singlerawz-cert.pub")
+	RUN ../generate-test-certs "$SINGLERAWZ" "$tmpdir/user-singlerawz-cert.pub"
+	GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-singlerawz-cert.pub")
 	EXPECT_EQ "$EXPECTED" "$GOT"
 fi
 SUCCESS
@@ -164,12 +164,12 @@ EXPECTED="certificate 'test' (1 principal) contains 1 HIBA grant
 grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] id = '1'"
-VERBOSE='' RUN ../generate-test-certs "$SINGLEB64" "$tmpdir/user-singleb64-cert.pub"
-GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-singleb64-cert.pub")
+RUN ../generate-test-certs "$SINGLEB64" "$tmpdir/user-singleb64-cert.pub"
+GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-singleb64-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 if [[ -n "$WITH_EXTENSION_COMPRESSION" ]]; then
-	VERBOSE='' RUN ../generate-test-certs "$SINGLEB64Z" "$tmpdir/user-singleb64z-cert.pub"
-	GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-singleb64z-cert.pub")
+	RUN ../generate-test-certs "$SINGLEB64Z" "$tmpdir/user-singleb64z-cert.pub"
+	GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-singleb64z-cert.pub")
 	EXPECT_EQ "$EXPECTED" "$GOT"
 fi
 SUCCESS
@@ -184,12 +184,12 @@ grant@hibassh.dev (v1):
 grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] id = '2'"
-VERBOSE='' RUN ../generate-test-certs "$MULTIRAW" "$tmpdir/user-multiraw-cert.pub"
-GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-multiraw-cert.pub")
+RUN ../generate-test-certs "$MULTIRAW" "$tmpdir/user-multiraw-cert.pub"
+GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-multiraw-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 if [[ -n "$WITH_EXTENSION_COMPRESSION" ]]; then
-	VERBOSE='' RUN ../generate-test-certs "$MULTIRAWZ" "$tmpdir/user-multirawz-cert.pub"
-	GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-multirawz-cert.pub")
+	RUN ../generate-test-certs "$MULTIRAWZ" "$tmpdir/user-multirawz-cert.pub"
+	GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-multirawz-cert.pub")
 	EXPECT_EQ "$EXPECTED" "$GOT"
 fi
 SUCCESS
@@ -204,12 +204,12 @@ grant@hibassh.dev (v1):
 grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] id = '2'"
-VERBOSE='' RUN ../generate-test-certs "$MULTIB64" "$tmpdir/user-multib64-cert.pub"
-GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-multib64-cert.pub")
+RUN ../generate-test-certs "$MULTIB64" "$tmpdir/user-multib64-cert.pub"
+GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-multib64-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 if [[ -n "$WITH_EXTENSION_COMPRESSION" ]]; then
-	VERBOSE='' RUN ../generate-test-certs "$MULTIB64Z" "$tmpdir/user-multib64z-cert.pub"
-	GOT=$(RUN ../hiba-gen -d -f "$tmpdir/user-multib64z-cert.pub")
+	RUN ../generate-test-certs "$MULTIB64Z" "$tmpdir/user-multib64z-cert.pub"
+	GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-multib64z-cert.pub")
 	EXPECT_EQ "$EXPECTED" "$GOT"
 fi
 SUCCESS
@@ -247,7 +247,7 @@ EXPECTED="certificate 'user1' (1 principal) contains 1 HIBA grant
  principal: 'user1'
 grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/users/user1-cert.pub")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/users/user1-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 EXPECTED="certificate 'user2' (1 principal) contains 2 HIBA grants
  principal: 'user2'
@@ -258,7 +258,7 @@ grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'
  [1] purpose = 'testing'
  [2] role = 'tester'"
-GOT=$(RUN ../hiba-gen -d -f "$dest/users/user2-cert.pub")
+GOT=$(RUN_T ../hiba-gen -d -f "$dest/users/user2-cert.pub")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
 #####
@@ -268,13 +268,13 @@ EXPECTED="certificate 'user1' (1 principal) contains 1 HIBA grant
  principal: 'user1'
 grant@hibassh.dev (v1):
  [0] domain = 'hibassh.dev'"
-GOT=$(RUN ../hiba-gen -d -f "$(cat $dest/users/user1-cert.pub)")
+GOT=$(RUN_T ../hiba-gen -d -f "$(cat $dest/users/user1-cert.pub)")
 EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: allow grant"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user1" -r root -p user1 "$dest/policy/grants/all")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user1" -r root -p user1 "$dest/policy/grants/all")
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
@@ -282,7 +282,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: deny missing field"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user1" -r root -p user1 "$dest/policy/grants/location:eu")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user1" -r root -p user1 "$dest/policy/grants/location:eu")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 40 "$GOTCODE"
@@ -290,7 +290,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: deny mismatch field"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user1" -r tester -p user1 "$dest/policy/grants/purpose:testing")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user1" -r tester -p user1 "$dest/policy/grants/purpose:testing")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 48 "$GOTCODE"
@@ -298,7 +298,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: deny bad role"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r root -p user1 "$dest/policy/grants/purpose:testing")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user2" -r root -p user1 "$dest/policy/grants/purpose:testing")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 46 "$GOTCODE"
@@ -306,11 +306,11 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: allow when multiple roles"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user1 -p user1 "$dest/policy/grants/2roles")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user1 -p user1 "$dest/policy/grants/2roles")
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user2 -p user1 "$dest/policy/grants/2roles")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user2 -p user1 "$dest/policy/grants/2roles")
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
@@ -318,7 +318,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: allow PRINCIPALS role"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user1 -p user1 "$dest/policy/grants/selfonly")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user1 -p user1 "$dest/policy/grants/selfonly")
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
@@ -326,7 +326,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: deny PRINCIPALS role"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user2 -p user1 "$dest/policy/grants/selfonly")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user2" -r user2 -p user1 "$dest/policy/grants/selfonly")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 46 "$GOTCODE"
@@ -334,7 +334,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: print options"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user1" -r root -p user1 "$dest/policy/grants/lockedcmd")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user1" -r root -p user1 "$dest/policy/grants/lockedcmd")
 GOTCODE=$?
 EXPECT_EQ "command=\"uname -a\" user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
@@ -342,7 +342,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: certificate: allow"
-GOT=$(RUN ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1-cert.pub")
+GOT=$(RUN_T ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1-cert.pub")
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
@@ -351,7 +351,7 @@ SUCCESS
 
 START_TEST "hiba-chk: certificate: deny multiple identities"
 RUN ../hiba-ca.sh -d "$dest" -s -h -I host3 -V +30d -H owner:user1 -H owner:user2 -- -P secret &>> "$log"
-GOT=$(RUN ../hiba-chk -i "$dest/hosts/host3-cert.pub" -r root "$dest/users/user1-cert.pub")
+GOT=$(RUN_T ../hiba-chk -i "$dest/hosts/host3-cert.pub" -r root "$dest/users/user1-cert.pub")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 3 "$GOTCODE"
@@ -359,7 +359,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: certificate: deny"
-GOT=$(RUN ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user2-cert.pub")
+GOT=$(RUN_T ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user2-cert.pub")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 48 "$GOTCODE"
@@ -367,11 +367,11 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: certificate: expired grant"
-RUN ../hiba-gen -f "$dest/policy/grants/all:1s" domain hibassh.dev validity 1 &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/all:1s" domain hibassh.dev validity 1 &>> "$log"
 RUN ../hiba-ca.sh -d "$dest" -p -I user1 -H all:1s &>> "$log"
 RUN ../hiba-ca.sh -d "$dest" -s -u -I user1 -H all:1s -- -P secret &>> "$log"
 sleep 2
-GOT=$(RUN ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1-cert.pub")
+GOT=$(RUN_T ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1-cert.pub")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 42 "$GOTCODE"
@@ -380,7 +380,7 @@ SUCCESS
 
 START_TEST "hiba-chk: certificate: no grant"
 RUN ../hiba-ca.sh -d "$dest" -s -u -I user1 -- -P secret &>> "$log"
-GOT=$(RUN ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1-cert.pub")
+GOT=$(RUN_T ../hiba-chk -i "$dest/hosts/host1-cert.pub" -r root "$dest/users/user1-cert.pub")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 47 "$GOTCODE"
@@ -388,14 +388,14 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: create file"
-RUN ../hiba-grl -f "$dest/grl.manual" -r -s 43 1 &>> "$log"
+RUN_T ../hiba-grl -f "$dest/grl.manual" -r -s 43 1 &>> "$log"
 GOTCODE=$?
 EXPECT_EQ 0 "$GOTCODE"
 SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: update new serial"
-RUN ../hiba-grl -f "$dest/grl.manual" -r -s 0x1234 2 3 &>> "$log"
+RUN_T ../hiba-grl -f "$dest/grl.manual" -r -s 0x1234 2 3 &>> "$log"
 GOTCODE=$?
 EXPECT_EQ 0 "$GOTCODE"
 GRL_TIMESTAMP=$(../hiba-grl -f "$dest/grl.manual" -d | grep timestamp | awk '{print $2}')
@@ -403,7 +403,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: dump file"
-GOT=$(RUN ../hiba-grl -f "$dest/grl.manual" -d)
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl.manual" -d)
 GOTCODE=$?
 EXPECTED="HIBA GRL (v1):
   comment: Generated using hiba-grl
@@ -417,7 +417,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: filter by serial"
-GOT=$(RUN ../hiba-grl -f "$dest/grl.manual" -d -s 0x1234)
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl.manual" -d -s 0x1234)
 GOTCODE=$?
 EXPECTED="HIBA GRL (v1):
   comment: Generated using hiba-grl
@@ -430,7 +430,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: test valid"
-GOT=$(RUN ../hiba-grl -f "$dest/grl.manual" -t -s 0x1234 0)
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl.manual" -t -s 0x1234 0)
 GOTCODE=$?
 EXPECTED="[0000000000001234]: 0 Valid"
 EXPECT_EQ "$EXPECTED" "$GOT"
@@ -439,7 +439,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: test revoked"
-GOT=$(RUN ../hiba-grl -f "$dest/grl.manual" -t -s 0x1234 2)
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl.manual" -t -s 0x1234 2)
 GOTCODE=$?
 EXPECTED="[0000000000001234]: 2 Revoked"
 EXPECT_EQ "$EXPECTED" "$GOT"
@@ -448,7 +448,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: test multiple"
-GOT=$(RUN ../hiba-grl -f "$dest/grl.manual" -t -s 0x1234 0 1 2 3)
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl.manual" -t -s 0x1234 0 1 2 3)
 GOTCODE=$?
 EXPECTED="[0000000000001234]: 0 Valid
 [0000000000001234]: 1 Valid
@@ -460,7 +460,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: non revoked grant"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user1" -g "$dest/grl.manual" -r root -p user1 "$dest/policy/grants/all")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user1" -g "$dest/grl.manual" -r root -p user1 "$dest/policy/grants/all")
 GOTCODE=$?
 EXPECT_EQ "user1" "$GOT"
 EXPECT_EQ 0 "$GOTCODE"
@@ -468,7 +468,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: update existing serial"
-RUN ../hiba-grl -f "$dest/grl.manual" -r -s 43 0 &>> "$log"
+RUN_T ../hiba-grl -f "$dest/grl.manual" -r -s 43 0 &>> "$log"
 GOTCODE=$?
 EXPECT_EQ 0 "$GOTCODE"
 GRL_TIMESTAMP=$(../hiba-grl -f "$dest/grl.manual" -d | grep timestamp | awk '{print $2}')
@@ -476,7 +476,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-grl: revoke: dump file"
-GOT=$(RUN ../hiba-grl -f "$dest/grl.manual" -d)
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl.manual" -d)
 GOTCODE=$?
 EXPECTED="HIBA GRL (v1):
   comment: Generated using hiba-grl
@@ -490,7 +490,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-chk: extension: revoked grant"
-GOT=$(RUN ../hiba-chk -i "$dest/policy/identities/owner:user1" -g "$dest/grl.manual" -r root -p user1 "$dest/policy/grants/all")
+GOT=$(RUN_T ../hiba-chk -i "$dest/policy/identities/owner:user1" -g "$dest/grl.manual" -r root -p user1 "$dest/policy/grants/all")
 GOTCODE=$?
 EXPECT_EQ "" "$GOT"
 EXPECT_EQ 43 "$GOTCODE"
@@ -506,7 +506,7 @@ SUCCESS
 #####
 
 START_TEST "hiba-ca.sh: extension: inspect logs"
-RUN ../hiba-gen -f "$dest/policy/grants/toberemoved" domain hibassh.dev nomatch true &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/toberemoved" domain hibassh.dev nomatch true &>> "$log"
 RUN ../hiba-ca.sh -d "$dest" -p -I user1 -H toberemoved -- -P secret &>> "$log"
 RUN ../hiba-ca.sh -d "$dest" -s -u -I user1 -H toberemoved -- -P secret &>> "$log"
 GOT_SERIAL=$(tail -n 1 "$dest/logs" | cut -d, -f2)
@@ -518,7 +518,7 @@ SUCCESS
 START_TEST "hiba-ca.sh: extension: revoke grant from policy remove"
 echo y | RUN ../hiba-ca.sh -d "$dest" -p -r -I user1 -H toberemoved -- -P secret &>> "$log"
 SERIAL="$(printf '0x%.16x' $GOT_SERIAL)"
-GOT=$(RUN ../hiba-grl -f "$dest/grl" -d -s $GOT_SERIAL | grep "$SERIAL")
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl" -d -s $GOT_SERIAL | grep "$SERIAL")
 EXPECT_EQ "  [$SERIAL]: 10" "$GOT"
 SUCCESS
 #####
@@ -529,7 +529,7 @@ RUN ../hiba-ca.sh -d "$dest" -s -u -I user1 -H toberemoved -- -P secret &>> "$lo
 echo y | RUN ../hiba-ca.sh -d "$dest" -k -r -H "toberemoved" &>> "$log"
 GOT_SERIAL=$(tail -n 1 "$dest/logs" | cut -d, -f2)
 SERIAL="$(printf '0x%.16x' $GOT_SERIAL)"
-GOT=$(RUN ../hiba-grl -f "$dest/grl" -d -s $GOT_SERIAL | grep "$SERIAL")
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl" -d -s $GOT_SERIAL | grep "$SERIAL")
 EXPECT_EQ "  [$SERIAL]: 10" "$GOT"
 SUCCESS
 #####
@@ -539,7 +539,7 @@ RUN ../hiba-ca.sh -d "$dest" -s -u -I user1 -H all -H toberemoved -- -P secret &
 echo y | RUN ../hiba-ca.sh -d "$dest" -k -r -H "toberemoved" &>> "$log"
 GOT_SERIAL=$(tail -n 1 "$dest/logs" | cut -d, -f2)
 SERIAL="$(printf '0x%.16x' $GOT_SERIAL)"
-GOT=$(RUN ../hiba-grl -f "$dest/grl" -d -s $GOT_SERIAL | grep "$SERIAL")
+GOT=$(RUN_T ../hiba-grl -f "$dest/grl" -d -s $GOT_SERIAL | grep "$SERIAL")
 EXPECT_EQ "  [$SERIAL]: 20" "$GOT"
 SUCCESS
 #####

--- a/testdata/test-utils.sh
+++ b/testdata/test-utils.sh
@@ -7,6 +7,7 @@
 dest="${DEST:-$(mktemp -d)}"
 log="${LOG:-/tmp/hiba-regression-test.log}"
 cleanup="${CLEANUP:-1}"
+run_under="${RUN_UNDER:-}"
 
 tmpdir="$dest/tmp"
 mkdir -p "$tmpdir"
@@ -35,8 +36,19 @@ RUN() {
 	CMD=$1
 	shift 1
 
-	echo "= Running $CMD $VERBOSE $@" >>$log
-	$CMD $VERBOSE "$@" 2>>$log | tee -a "$log"
+	echo "= Running $CMD $@" >>$log
+	$CMD "$@" 2>>$log | tee -a "$log"
+	exit_code=${PIPESTATUS[0]}
+	echo "= Exit code $exit_code" >>$log
+	return $exit_code
+}
+
+RUN_T() {
+	CMD=$1
+	shift 1
+
+	echo "= Running $run_under $CMD $VERBOSE $@" >>$log
+	$run_under $CMD $VERBOSE "$@" 2>>$log | tee -a "$log"
 	exit_code=${PIPESTATUS[0]}
 	echo "= Exit code $exit_code" >>$log
 	return $exit_code


### PR DESCRIPTION
The 3 HIBA binaries (hiba-gen, hiba-chk and hiba-grl) can now run under valgrind (for instance) to provide better diagnostics about memory management in libhiba.

This also fix one minor leak on the hiba-gen command line tool detected using this mechanism.