### PR TITLE
Update documentation to explain the current extension format version.

### DIFF
--- a/PROTOCOL.extensions
+++ b/PROTOCOL.extensions
@@ -41,7 +41,10 @@ Where type is defined by the following:
 #define HIBA_GRANT_EXT		'g'
 ```
 
-The current version starts at 1, and so does minimum supported version.
+The current extension format version is 2, but can be reset to 1 when a grant
+is not using negative constraint matching in order to maximize compatibility
+with older HIBA binaries without compromizing security. The minimum supported
+extension format version is still 1.
 
 The rest of the data is a list of strings key1, value1, key2, value2, ...
 There must be exactly one value per key.


### PR DESCRIPTION
With the addition of negative constraint matching, and in order to avoid unintended authiorizations, the extension format version was increased to 2 for all grants actually using negative matching, but can stay at 1 for everything else (grant with only positive matching and identities).