### PR TITLE
Update documentation to clarify min_version versus version requirement.

### DIFF
--- a/PROTOCOL.extensions
+++ b/PROTOCOL.extensions
@@ -41,10 +41,12 @@ Where type is defined by the following:
 #define HIBA_GRANT_EXT		'g'
 ```
 
-The current extension format version is 2, but can be reset to 1 when a grant
-is not using negative constraint matching in order to maximize compatibility
-with older HIBA binaries without compromizing security. The minimum supported
-extension format version is still 1.
+The current extension format version is 2, which supports negative constraint
+matching. The extension format minimum version is still 1 when only positive
+constraint matching is used (to maximize backward compatibility), but must
+be increased to 2 whenever a negative matching constraint is added to a grant
+(to avoid compromizing security with unexpected behavior when parsing newer
+extensions on older HIBA binaries).
 
 The rest of the data is a list of strings key1, value1, key2, value2, ...
 There must be exactly one value per key.


### PR DESCRIPTION
Previous commit (72b8445d702e71a2b30e72832f80b98de43d36d7) explained the high level idea but creates confusion between version and min_version fields.

This commit clarifies both fields expected values.