### PR TITLE
Verify the incoming authentication has a type grant.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -175,6 +175,8 @@ hibachk_authorize(const struct hibaenv *env, const u_int64_t user_serial, const 
 	/* Basic sanity hibachks. */
 	if ((env == NULL) || (grant == NULL))
 		return HIBA_BAD_PARAMS;
+	if (hibaext_type(grant) != HIBA_GRANT_EXT)
+		return HIBA_BAD_PARAMS;
 	if ((ret = hibaext_sanity_check(grant)) < 0)
 		return ret;
 


### PR DESCRIPTION
Allowing authentication using identity doesn't cause much harm, but can cause confusion when user sets up their OpenSSH config wrong and pass the invert command line parameters. With this check, authorization will fail fast.