### PR TITLE
test-utils: copy built files to the test temporary folder.

### DIFF
--- a/testdata/test-utils.sh
+++ b/testdata/test-utils.sh
@@ -14,6 +14,11 @@ mkdir -p "$tmpdir"
 
 date > "$log"
 
+# Prepare dest dir
+mkdir -p "$dest/bin"
+rsync -a ../hiba-grl ../hiba-gen ../hiba-chk ../.libs $dest/bin/
+export PATH="$dest/bin:$PATH"
+
 # Define extension formats
 SINGLERAW=1
 SINGLERAWZ=2


### PR DESCRIPTION
The test utils script also updates the PATH to ensure regression tests run against the latest binaries rather than the preinstalled ones.