### PR TITLE
Document GRL certificate serial section size

### DIFF
--- a/PROTOCOL.grl
+++ b/PROTOCOL.grl
@@ -31,10 +31,11 @@ Where magic is defined as:
 #define HIBA_GRL_MAGIC	0x4847524c
 ```
 
-The subsequent section contains a sorted list of certificate serial numbers
-associated with an offset. Each entry has a fixed size in order to allow quick
-lookups. The offset is used to find the corresponding bitmap of revoked grants
-in the next section.
+The subsequent section begins with a uint64 indicating the number of entries in
+a sorted list of certificate serial numbers each of which is associated with an
+offset. Entries in the list have a fixed size in order to allow quick lookups.
+The offset is used to find the corresponding bitmap of revoked grants in the
+next section.
 
 ```
 	uint64 serial


### PR DESCRIPTION
Previously PROTOCOL.grl omitted details about the uint64 which indicates the number of fixed size entries in the serials section of the binary format grant revocation list.  The serial section size is required to differentiate between the final entry in the serials section and the revoked grants bitmask section.