### PR TITLE
Improve support for quotes in 'option' constraint.

### DIFF
--- a/extensions.c
+++ b/extensions.c
@@ -761,11 +761,15 @@ hibaext_sanity_check(const struct hibaext *ext) {
 				size_t i;
 				int quoted = 0;
 				int dquoted = 0;
+				int escaped = 0;
 
 				if (negative_matching)
 					ret = HIBA_UNEXPECTED_KEY;
 				else for (i = 0; i < strlen(value); ++i) {
 					switch (value[i]) {
+					case '\\':
+						escaped = !escaped;
+						continue;
 					case '\n':
 						ret = HIBA_GRANT_BADOPTIONS;
 						break;
@@ -775,13 +779,14 @@ hibaext_sanity_check(const struct hibaext *ext) {
 						break;
 					case '\'':
 						if (!dquoted)
-							quoted = (quoted+1)%2;
+							quoted = !quoted;
 						break;
 					case '"':
-						if (!quoted)
-							dquoted = (dquoted+1)%2;
+						if (!quoted && !escaped)
+							dquoted = !dquoted;
 						break;
 					}
+					escaped = 0;
 					if (ret != 0)
 						break;
 				}

--- a/testdata/regression-test.sh
+++ b/testdata/regression-test.sh
@@ -84,6 +84,7 @@ RUN_T ../hiba-gen -f "$dest/policy/grants/multinegativematch" domain hibassh.dev
 RUN_T ../hiba-gen -f "$dest/policy/grants/wildcardhost" domain hibassh.dev 'hostname' '*' &>> "$log"
 RUN_T ../hiba-gen -f "$dest/policy/grants/wildcardhost_invalid" domain hibassh.dev 'hostname' '__invalid__*' &>> "$log"
 RUN_T ../hiba-gen -f "$dest/policy/grants/wildcardrole" domain hibassh.dev 'role' 'user*' &>> "$log"
+RUN_T ../hiba-gen -f "$dest/policy/grants/force_command" domain hibassh.dev options 'command="echo \"hello world\""' &>> "$log"
 EXPECT_EXISTS "$dest/policy/grants/all"
 EXPECT_EXISTS "$dest/policy/grants/location:eu"
 EXPECT_EXISTS "$dest/policy/grants/purpose:testing"
@@ -96,6 +97,7 @@ EXPECT_EXISTS "$dest/policy/grants/multinegativematch"
 EXPECT_EXISTS "$dest/policy/grants/wildcardhost"
 EXPECT_EXISTS "$dest/policy/grants/wildcardhost_invalid"
 EXPECT_EXISTS "$dest/policy/grants/wildcardrole"
+EXPECT_EXISTS "$dest/policy/grants/force_command"
 EXPECT_NOT_EXISTS "$dest/policy/grants/badcmd"
 SUCCESS
 #####
@@ -224,6 +226,15 @@ if [[ -n "$WITH_EXTENSION_COMPRESSION" ]]; then
 	GOT=$(RUN_T ../hiba-gen -d -f "$tmpdir/user-multib64z-cert.pub")
 	EXPECT_EQ "$EXPECTED" "$GOT"
 fi
+SUCCESS
+#####
+
+START_TEST "hiba-gen: escaped quotes in options"
+EXPECTED="grant@hibassh.dev (v2):
+ [0] domain = 'hibassh.dev'
+ [1] options = 'command=\"echo \\\"hello world\\\"\"'"
+GOT=$(RUN_T ../hiba-gen -d -f "$(cat $dest/policy/grants/force_command)")
+EXPECT_EQ "$EXPECTED" "$GOT"
 SUCCESS
 #####
 


### PR DESCRIPTION
The option constraint in a HIBA grant can be used for restricting users to a given command similar to authorized_keys or authorized_users.

The command can contain quotes by escaping them with a backslash, which was not implemented in the sanity check until now.