### PR TITLE
fix build against upcoming gcc-14

### DIFF
--- a/certificates.c
+++ b/certificates.c
@@ -36,7 +36,7 @@ struct hibacert {
 
 struct hibacert*
 hibacert_new() {
-	struct hibacert *cert = calloc(sizeof(struct hibacert), 1);
+	struct hibacert *cert = calloc(1, sizeof(struct hibacert));
 	return cert;
 }
 
@@ -68,11 +68,11 @@ hibacert_from_ext(struct hibacert *cert, struct hibaext *ext,
 	cert->key->cert->valid_after = validity;
 	if (principal != NULL) {
 		cert->key->cert->nprincipals = 1;
-		cert->key->cert->principals = calloc(sizeof(char*), 1);
+		cert->key->cert->principals = calloc(1, sizeof(char*));
 		cert->key->cert->principals[0] = strdup(principal);
 	}
 	cert->nexts = 1;
-	cert->exts = calloc(sizeof(struct hibaext*), 1);
+	cert->exts = calloc(1, sizeof(struct hibaext*));
 	cert->exts[0] = ext;
 
 	return HIBA_OK;

--- a/checks.c
+++ b/checks.c
@@ -314,7 +314,7 @@ hibaenv_from_host(const struct hibacert *host, const struct hibacert *user, cons
 	int ret;
 	uint32_t i;
 	struct hibaext **exts;
-	struct hibaenv *env = calloc(sizeof(struct hibaenv), 1);
+	struct hibaenv *env = calloc(1, sizeof(struct hibaenv));
 
 	if ((ret = hibacert_hibaexts(host, &exts, &len)) < 0) {
 		debug2("hibaenv_from_host: hibacert_hibaexts returned %d: %s", ret, hiba_err(ret));

--- a/extensions.c
+++ b/extensions.c
@@ -205,7 +205,7 @@ hibaext_decode(struct hibaext *ext, struct sshbuf *blob) {
 	debug3("hibaext_decode: reading %d pairs", ext->npairs);
 	pair = &ext->pairs;
 	for (i = 0; i < ext->npairs; ++i) {
-		pair->next = calloc(sizeof(struct pair), 1);
+		pair->next = calloc(1, sizeof(struct pair));
 		pair = pair->next;
 		if ((ret = sshbuf_get_cstring(d, &pair->key, NULL)) != 0) {
 			debug3("hibaext_decode: sshbuf_get_cstring returned %d: %s", ret, ssh_err(ret));
@@ -549,7 +549,7 @@ int hibaext_encode(const struct hibaext *ext, struct sshbuf *blob) {
 
 struct hibaext*
 hibaext_new() {
-	struct hibaext *ext = calloc(sizeof(struct hibaext), 1);
+	struct hibaext *ext = calloc(1, sizeof(struct hibaext));
 	return ext;
 }
 
@@ -688,7 +688,7 @@ hibaext_add_pair(struct hibaext *ext, const char *key, const char *value) {
 
 	debug3("hibaext_add_pair: add key '%s' = '%s'", key, value);
 	ext->npairs++;
-	new = calloc(sizeof(struct pair), 1);
+	new = calloc(1, sizeof(struct pair));
 	new->key = strdup(key);
 	new->val = strdup(value);
 	pair = &ext->pairs;

--- a/revocations.c
+++ b/revocations.c
@@ -74,7 +74,7 @@ hibagrl_free(struct hibagrl *grl) {
 
 struct hibagrl*
 hibagrl_new() {
-	struct hibagrl *grl = calloc(sizeof(struct hibagrl), 1);
+	struct hibagrl *grl = calloc(1, sizeof(struct hibagrl));
 	return grl;
 }
 
@@ -430,7 +430,7 @@ hibagrl_revoke_grant(struct hibagrl *grl, u_int64_t serial, u_int32_t lo, u_int3
 	if (r->size < required_size) {
 		char *prev_map = r->map;
 		debug2("hibagrl_revoke_grant: resizing map to %d", required_size);
-		r->map = calloc(required_size, 1);
+		r->map = calloc(1, required_size);
 		if (prev_map) {
 			/* if we already add revocations for this serial, we
 			 * must copy them. */


### PR DESCRIPTION
We will hit -Werror=calloc-transposed-args when we start moving to gcc-14. Migrate to the new API to make sure no build fails.