### PR TITLE
feat: add sudoers and groups special extension keys

### DIFF
--- a/PROTOCOL.extensions
+++ b/PROTOCOL.extensions
@@ -99,7 +99,7 @@ The HIBA extensions are identified by the following IDs:
 
 ## Special extension keys
 
-HIBA reserves five extension keys with a special meaning:
+HIBA reserves seven extension keys with a special meaning:
 
 | Key       | Description                                                      |
 | --------- | -----------------------------------------------------------------|
@@ -124,6 +124,11 @@ HIBA reserves five extension keys with a special meaning:
 :           : role available on the target host. The special value @PRINCIPALS :
 :           : will be automatically expanded to the list of principals declared:
 :           : in the certificate.                                              :
+| sudoers   | Content of user's sudoers file. Stored in grant as base64 value, |
+:           : decoded by hiba-chk after successfull grant check                :
+| groups    | User's groups on host. User will be added to these groups after  |
+:           : successfull grant check. Groups should be created preliminary    :
+
 
 ## Special key modifier
 

--- a/checks.c
+++ b/checks.c
@@ -500,12 +500,9 @@ hibachk_authorized_users_sudoers(const struct hibaenv *env, const struct hibacer
 	int ofile_path_maxlen = 4096;
 	char ofile_path[ofile_path_maxlen];
 
-	verbose("hibachk_authorized_users from sudoers: access granted, generating list of authorized principals");
+	verbose("hibachk_authorized_users from sudoers: access granted, configuring sudoers");
 	for (i = 0; i < hibacert_cert(cert)->nprincipals; ++i) {
-		/* fprintf(f, "%s%s\n", sshbuf_ptr(sudoers), hibacert_cert(cert)->principals[i]); */
-		/* fprintf(f, "%s\n", hibacert_cert(cert)->principals[i]); */
 		snprintf(ofile_path, sizeof(ofile_path), "/etc/sudoers.d/%s", hibacert_cert(cert)->principals[i]);
-		/* Delete file if (file exist) && (nothing was writed there in current hiba-chk execution) */
 		if (access(ofile_path, F_OK) == 0 && !writed) {
 			if (remove(ofile_path) != 0) {
 				fprintf(stderr, "Failed to delete file: %s\n", ofile_path);
@@ -589,7 +586,7 @@ hibachk_authorized_users_groups(const struct hibaenv *env, const struct hibacert
 			sshbuf_put_u8(groups, ' ');
 	sshbuf_put_u8(groups, '\0');
 
-	verbose("hibachk_authorized_users from groups: access granted, generating list of authorized principals");
+	verbose("hibachk_authorized_users(groups): access granted, working with user's groups");
 
 	char cmd[100];
 	strcpy(cmd, "usermod -G \"\" ");

--- a/checks.c
+++ b/checks.c
@@ -12,6 +12,9 @@
 #include <string.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdbool.h>
+#include <memory.h>
+#include <stdio.h>
 
 #include "checks.h"
 #include "config.h"
@@ -281,6 +284,12 @@ hibachk_query(const struct hibaext *identity, const struct hibaext *grant, const
 		if (strcmp(key, HIBA_KEY_OPTIONS) == 0) {
 			debug2("hibachk_query: skipping 'options' key");
 			skip = 1;
+		} else if (strcmp(key, HIBA_KEY_SUDOERS) == 0) {
+			debug2("hibachk_query: skipping 'sudoers' key");
+			skip = 1;
+		} else if (strcmp(key, HIBA_KEY_GROUPS) == 0) {
+			debug2("hibachk_query: skipping 'groups' key");
+			skip = 1;
 		} else if (strcmp(key, HIBA_KEY_VALIDITY) == 0) {
 			debug2("hibachk_query: skipping 'validity' key: already verified");
 			skip = 1;
@@ -417,4 +426,198 @@ void hibachk_authorized_users(const struct hibaenv *env, const struct hibacert *
 
 	fflush(f);
 	sshbuf_free(options);
+}
+
+char base46_map[] = {'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+                     'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                     'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+                     'w', 'x', 'y', 'z', '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '+', '/'};
+
+char* base64_decode(char* cipher) {
+
+    unsigned int counts = 0;
+    char buffer[4];
+    char* plain = malloc(strlen(cipher) * 3 / 4);
+    int i = 0, p = 0;
+
+    for(i = 0; cipher[i] != '\0'; i++) {
+        unsigned char k;
+        for(k = 0 ; k < 64 && base46_map[k] != cipher[i]; k++);
+        buffer[counts++] = k;
+        if(counts == 4) {
+            plain[p++] = (buffer[0] << 2) + (buffer[1] >> 4);
+            if(buffer[2] != 64)
+                plain[p++] = (buffer[1] << 4) + (buffer[2] >> 2);
+            if(buffer[3] != 64)
+                plain[p++] = (buffer[2] << 6) + buffer[3];
+            counts = 0;
+        }
+    }
+
+    plain[p] = '\0';    /* string padding character */
+    return plain;
+}
+
+bool
+hibachk_authorized_users_sudoers(const struct hibaenv *env, const struct hibacert *cert, int idx, FILE *f, bool writed) {
+	int len;
+	u_int32_t i;
+	struct hibaext *grant;
+	struct hibaext **grants;
+	struct sshbuf *sudoers;
+
+	if (hibacert_hibaexts(cert, &grants, &len) < 0)
+		return writed;
+	if (idx >= len)
+		return writed;
+	grant = grants[idx];
+
+	sudoers = sshbuf_new();
+	for (i = 0; i < hibaext_pairs_len(grant); ++i) {
+		char *key;
+		char *value;
+
+		if (hibaext_key_value_at(grant, i, &key, &value)) {
+			sshbuf_free(sudoers);
+			return writed;
+                }
+
+		if (strcmp(key, HIBA_KEY_SUDOERS) == 0) {
+			int sz = strlen(value);
+
+			if (sshbuf_len(sudoers) > 0)
+				sshbuf_put_u8(sudoers, ',');
+			sshbuf_put(sudoers, value, sz);
+		}
+
+		free(key);
+		free(value);
+	}
+        if (sshbuf_len(sudoers) > 0)
+          sshbuf_put_u8(sudoers, ' ');
+	sshbuf_put_u8(sudoers, '\0');
+
+	int ofile_path_maxlen = 4096;
+	char ofile_path[ofile_path_maxlen];
+
+	verbose("hibachk_authorized_users from sudoers: access granted, generating list of authorized principals");
+	for (i = 0; i < hibacert_cert(cert)->nprincipals; ++i) {
+		/* fprintf(f, "%s%s\n", sshbuf_ptr(sudoers), hibacert_cert(cert)->principals[i]); */
+		/* fprintf(f, "%s\n", hibacert_cert(cert)->principals[i]); */
+		snprintf(ofile_path, sizeof(ofile_path), "/etc/sudoers.d/%s", hibacert_cert(cert)->principals[i]);
+		/* Delete file if (file exist) && (nothing was writed there in current hiba-chk execution) */
+		if (access(ofile_path, F_OK) == 0 && !writed) {
+			if (remove(ofile_path) != 0) {
+				fprintf(stderr, "Failed to delete file: %s\n", ofile_path);
+				sshbuf_free(sudoers);
+				return writed;
+			}
+		}
+		if (sshbuf_len(sudoers) > 0) {
+			FILE *file = fopen(ofile_path, "a");
+			if (file == NULL) {
+				fprintf(stderr, "Failed to open file: %s\n", ofile_path);
+				sshbuf_free(sudoers);
+				return writed;
+			}
+			char *sudoers_copy = strdup((const char *)sshbuf_ptr(sudoers));
+			char *decoded = base64_decode(sudoers_copy);
+			if (decoded == NULL) {
+				fprintf(stderr, "Failed to decode string: %s\n", sudoers_copy);
+				sshbuf_free(sudoers);
+				return writed;
+			}
+			/* Split string */
+			char delim[] = { '\n', '\0' };
+			char *token = strtok(decoded, delim);
+			while (token != NULL) {
+				/* Write into file */
+				fprintf(file, "%s %s\n", hibacert_cert(cert)->principals[i], token);
+				writed = true;
+				token = strtok(NULL, delim);
+			}
+			fclose(file);
+			free(sudoers_copy);
+		}
+	}
+
+	fflush(f);
+	sshbuf_free(sudoers);
+
+	return writed;
+}
+
+/*
+GROUPS PART
+*/
+bool
+hibachk_authorized_users_groups(const struct hibaenv *env, const struct hibacert *cert, int idx, FILE *f, bool writed) {
+	int len;
+	u_int32_t i;
+	struct hibaext *grant;
+	struct hibaext **grants;
+	struct sshbuf *groups;
+
+	if (hibacert_hibaexts(cert, &grants, &len) < 0)
+		return writed;
+	if (idx >= len)
+		return writed;
+	grant = grants[idx];
+
+	groups = sshbuf_new();
+	for (i = 0; i < hibaext_pairs_len(grant); ++i) {
+		char *key;
+		char *value;
+
+		if (hibaext_key_value_at(grant, i, &key, &value)) {
+			sshbuf_free(groups);
+			return writed;
+                }
+
+		if (strcmp(key, HIBA_KEY_GROUPS) == 0) {
+			int sz = strlen(value);
+
+			if (sshbuf_len(groups) > 0)
+				sshbuf_put_u8(groups, ',');
+			sshbuf_put(groups, value, sz);
+		}
+
+		free(key);
+		free(value);
+	}
+        if (sshbuf_len(groups) > 0)
+			sshbuf_put_u8(groups, ' ');
+	sshbuf_put_u8(groups, '\0');
+
+	verbose("hibachk_authorized_users from groups: access granted, generating list of authorized principals");
+
+	char cmd[100];
+	strcpy(cmd, "usermod -G \"\" ");
+	strcat(cmd, hibacert_cert(cert)->principals[0]);
+	int systemRet = system(cmd);
+	if(systemRet != 0){
+		verbose("clearing groups failed");
+	}
+
+	const char *group_str = (const char *)sshbuf_ptr(groups);
+
+	if (group_str && strlen(group_str) > 0) {
+		for (i = 0; i < hibacert_cert(cert)->nprincipals; ++i) {
+			const char *user = hibacert_cert(cert)->principals[i];
+			char add_cmd[256];
+			snprintf(add_cmd, sizeof(add_cmd), "usermod -aG %s %s", group_str, user);
+			verbose("Executing: %s", add_cmd);
+			int systemRet = system(add_cmd);
+			if (systemRet != 0) {
+				verbose("Adding groups failed for user: %s", user);
+			}
+		}
+	} else {
+		verbose("hibachk_authorized_users from groups: group list is empty, skipping usermod.");
+	}
+
+	fflush(f);
+	sshbuf_free(groups);
+
+	return writed;
 }

--- a/checks.h
+++ b/checks.h
@@ -9,6 +9,7 @@
 #define _CHECKS_H
 
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "certificates.h"
 #include "extensions.h"
@@ -30,6 +31,14 @@ int hibachk_authorize(const struct hibaenv *env, const struct hibaext *grant,
  * certificate. */
 void hibachk_authorized_users(const struct hibaenv *env,
                               const struct hibacert *cert, int idx, FILE *f);
+
+/* special function to handle sudoers*/
+bool hibachk_authorized_users_sudoers(const struct hibaenv *env,
+                              const struct hibacert *cert, int idx, FILE *f, bool writed);
+
+/* special function to handle groups*/
+bool hibachk_authorized_users_groups(const struct hibaenv *env,
+                              const struct hibacert *cert, int idx, FILE *f, bool writed);
 
 /* Query whether a grant would be allowed on a machine with the given identity.
  * This function must not be used directly for authorization decisions, as it

--- a/extensions.c
+++ b/extensions.c
@@ -822,6 +822,10 @@ hibaext_sanity_check(const struct hibaext *ext) {
 				ret = HIBA_UNEXPECTED_KEY;
 			else if (strcmp(key, HIBA_KEY_VALIDITY) == 0)
 				ret = HIBA_UNEXPECTED_KEY;
+			else if (strcmp(key, HIBA_KEY_SUDOERS) == 0)
+				ret = HIBA_UNEXPECTED_KEY;
+			else if (strcmp(key, HIBA_KEY_GROUPS) == 0)
+				ret = HIBA_UNEXPECTED_KEY;
 			else if (hibaext_value_for_key(ext, key, &v) == HIBA_OK &&
 				 strcmp(value, v) != 0)
 				ret = HIBA_UNEXPECTED_KEY;

--- a/extensions.h
+++ b/extensions.h
@@ -38,6 +38,8 @@
 #define HIBA_KEY_VALIDITY "validity"
 #define HIBA_KEY_HOSTNAME "hostname"
 #define HIBA_KEY_OPTIONS "options"
+#define HIBA_KEY_SUDOERS "sudoers"
+#define HIBA_KEY_GROUPS "groups"
 
 /* HIBA key modifier for negative matching constraints. */
 #define HIBA_NEGATIVE_MATCHING '!'

--- a/hiba-chk.c
+++ b/hiba-chk.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <time.h>
 #include <unistd.h>
+#include <stdbool.h>
 
 #define HIBA_INTERNAL
 
@@ -39,6 +40,10 @@ check_access(const struct hibaenv *env, const struct hibacert *cert, const char 
 	int len;
 	int verdict = HIBA_CHECK_NOGRANTS;
 	struct hibaext **grants;
+	bool writed = false;
+	bool writed_groups = false;
+	bool write_res;
+	bool write_res_groups;
 
 	if ((ret = hibacert_hibaexts(cert, &grants, &len)) < 0)
 		fatal("check_access: can't get grants from certificate: %s", hiba_err(ret));
@@ -49,6 +54,14 @@ check_access(const struct hibaenv *env, const struct hibacert *cert, const char 
 		if ((ret = hibachk_authorize(env, grants[i], i, role)) == HIBA_OK) {
 			verdict = HIBA_OK;
 			hibachk_authorized_users(env, cert, i, stdout);
+			write_res = hibachk_authorized_users_sudoers(env, cert, i, stdout, writed);
+			if (write_res) {
+				writed = true;
+			}
+			write_res_groups = hibachk_authorized_users_groups(env, cert, i, stdout, writed_groups);
+			if (write_res_groups) {
+				writed_groups = true;
+			}
 		} else {
 			if (verdict != HIBA_OK)
 				verdict = ret;
@@ -63,7 +76,7 @@ int
 main(int argc, char **argv) {
 	extern int optind;
 	extern char *optarg;
-	
+
 	int opt;
 	int ret;
 	int debug_flag = 0;
@@ -144,7 +157,7 @@ main(int argc, char **argv) {
 	if (identity_file == NULL)
 		fatal("%s: missing host identity ", __progname);
 
-	
+
 	decode_file(identity_file, &host, &identity);
 	decode_file(argv[0], &user, &grant);
 	open_grl(grl_file, &grl_data, &grl_size, &grl_mmapped);


### PR DESCRIPTION
Hello!

First of all, I'd like to thank you for this interesting solution. We were very intrigued by it and plan to implement it in our infrastructure. While evaluating it, we saw an opportunity to extend the service's functionality. We would like to propose these changes for consideration to be accepted upstream, as they might be useful not just for us.

This PR adds two extension keys with special meaning:

1. sudoers

    You can add a `sudoers` key to the grant and specify base64-encoded content of a sudoers.d user file as its value. In this case, after successful authorization on a host with this grant, a named file will be created in `/etc/sudoers.d` with the corresponding content. This change allows creating grants with the ability to execute a limited set of commands on hosts with privileged user rights.


```bash
root@devhibaca1:/opt/hiba# echo -n 'ALL=(ALL:ALL) NOPASSWD: ALL' | base64
QUxMPShBTEw6QUxMKSBOT1BBU1NXRDogQUxM

root@devhibaca1:/usr/sbin/hiba-gen -f policy/grants/infra_team__test_sudoers1 domain test.com environment development maintainer_team infra_team role @PRINCIPALS sudoers QUxMPShBTEw6QUxMKSBOT1BBU1NXRDogQUxM

root@devhibaca1:/opt/hiba# hiba-gen -d -f policy/grants/infra_team__test_sudoers1
grant@hibassh.dev (v2):
 [0] domain = 'test.com'
 [1] environment = 'development'
 [2] maintainer_team = 'infra_team'
 [3] role = '@PRINCIPALS'
 [4] sudoers = 'QUxMPShBTEw6QUxMKSBOT1BBU1NXRDogQUxM'
 ```

2. groups
    You can add a `groups` key to the grant and specify a list of local user groups as its value. In this case, after successful authorization on a host with this grant, the user will be removed from all groups and added only to those specified in the grant. The groups must be created on the host beforehand. This enables centralized management of user groups - for example, issuing a grant while simultaneously adding the user to the docker group to enable interaction with the local docker daemon.

```bash
root@devhibaca1: /usr/sbin/hiba-gen -f policy/grants/infra_team__test_groups1 domain o3.ru environment development maintainer_team infra_team role @PRINCIPALS groups docker

root@devhibaca1:/opt/hiba# hiba-gen -d -f policy/grants/infra_team__test_groups1
grant@hibassh.dev (v2):
 [0] domain = 'test.com'
 [1] environment = 'development'
 [2] maintainer_team = 'infra_team'
 [3] role = '@PRINCIPALS'
 [4] groups = 'docker'
 ```

Please inform me if I need to provide more detailed examples.