### PR TITLE
include sys/types.h before log.h

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -10,6 +10,7 @@
 #include <limits.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/extensions.c
+++ b/extensions.c
@@ -8,6 +8,7 @@
 #include <errno.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "config.h"
 

--- a/hiba-chk.c
+++ b/hiba-chk.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/hiba-gen.c
+++ b/hiba-gen.c
@@ -9,6 +9,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include "log.h"

--- a/hiba-grl.c
+++ b/hiba-grl.c
@@ -9,6 +9,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/types.h>
 #include <time.h>
 #include <unistd.h>
 

--- a/revocations.c
+++ b/revocations.c
@@ -9,6 +9,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 #include <time.h>
 
 #include "errors.h"


### PR DESCRIPTION
OpenSSH 10.0 has some declarations in log.h that use the type `u_int`, which is usually provided by the platform's sys/types.h.

Including OpenSSH's `defines.h` might be a better fix, because it includes replacement types when the system's headers lack stuff, but that's a bit more risky to include as it replaces a bunch of stuff.