### PR TITLE
Consolidate dependency on OpenSSH headers.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,7 @@ ACLOCAL_AMFLAGS = -I m4
 ARFLAGS = cr
 AM_LIBTOOLFLAGS = "--preserve-dup-deps"
 
-include_HEADERS = hiba.h extensions.h errors.h checks.h certificates.h revocations.h
+include_HEADERS = hiba.h extensions.h errors.h checks.h certificates.h revocations.h openssh/includes.h
 
 lib_LTLIBRARIES = libhiba.la
 libhiba_la_SOURCES = extensions.c errors.c checks.c certificates.c revocations.c

--- a/certificates.c
+++ b/certificates.c
@@ -9,6 +9,8 @@
 #include <string.h>
 #include <sys/types.h>
 
+#include "config.h"
+
 #include "extensions.h"
 #include "certificates.h"
 #include "errors.h"

--- a/checks.c
+++ b/checks.c
@@ -14,8 +14,9 @@
 #include <time.h>
 #include <unistd.h>
 
-#include "checks.h"
 #include "config.h"
+
+#include "checks.h"
 #include "errors.h"
 #include "extensions.h"
 #include "log.h"

--- a/configure.ac
+++ b/configure.ac
@@ -5,12 +5,18 @@ m4_define([MAJOR], 1)
 m4_define([MINOR], 4)
 
 AC_PREREQ([2.69])
-AC_INIT([HIBA], [MAJOR.MINOR], [hibassh@google.com])
+AC_INIT([HIBA], [MAJOR.MINOR], [hibassh@google.com], [], [https://github.com/google/hiba])
 AC_CONFIG_SRCDIR([hiba.h])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])
 AC_LANG([C])
 AC_PROG_CC([cc gcc clang])
+
+AH_TOP([#ifndef HIBA_CONFIG_H_
+#define HIBA_CONFIG_H_
+
+#include "openssh/includes.h"])
+AH_BOTTOM([#endif  /* HIBA_CONFIG_H_ */])
 
 LT_INIT
 
@@ -121,13 +127,6 @@ AC_LINK_IFELSE(
 	], [AC_MSG_RESULT([no])],
 )
 LDFLAGS="$save_LDFLAGS"
-
-# Check for definition of max hostname length
-AC_CHECK_DECL(
-	[HOST_NAME_MAX], [], [AC_DEFINE([HOST_NAME_MAX], [64], [
-		Maximum supported hostname size if not already defined by OS.
-	])], [#include <limits.h>],
-)
 
 # Update flags.
 CFLAGS="$CFLAGS $extra_CFLAGS"
@@ -295,6 +294,15 @@ AC_SEARCH_LIBS([sshbuf_new], [ssh], [], [
 )
 AC_SUBST([extra_LIBS], [$LIBS])
 LIBS="$save_LIBS"
+
+# Check for definition of max hostname length
+# If undefined, it could still be provided by OpenSSH headers.
+AC_CHECK_DECL([HOST_NAME_MAX], [], AH_VERBATIM([HOST_NAME_MAX],
+	[/* Maximum supported hostname size if not already defined. */
+#ifndef HOST_NAME_MAX
+#define HOST_NAME_MAX 64
+#endif]), [#include <limits.h>],
+)
 
 # Checks for header files.
 AC_CHECK_HEADERS([inttypes.h limits.h stdint.h stdlib.h string.h sys/types.h unistd.h])

--- a/errors.c
+++ b/errors.c
@@ -6,7 +6,6 @@
  * https://developers.google.com/open-source/licenses/bsd
  */
 #include "errors.h"
-#include "ssherr.h"
 
 const char *hiba_err(int err) {
 	if (err == HIBA_OK)

--- a/hiba-chk.c
+++ b/hiba-chk.c
@@ -14,6 +14,8 @@
 
 #define HIBA_INTERNAL
 
+#include "config.h"
+
 #include "log.h"
 #include "hiba.h"
 #include "misc.h"

--- a/hiba-gen.c
+++ b/hiba-gen.c
@@ -12,6 +12,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "config.h"
+
 #include "log.h"
 #include "hiba.h"
 #include "misc.h"

--- a/hiba-grl.c
+++ b/hiba-grl.c
@@ -15,6 +15,8 @@
 
 #define HIBA_INTERNAL
 
+#include "config.h"
+
 #include "log.h"
 #include "hiba.h"
 #include "misc.h"

--- a/openssh/includes.h
+++ b/openssh/includes.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 The HIBA Authors
+ *
+ * Wrapper to openssh headers.
+ *
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file or at
+ * https://developers.google.com/open-source/licenses/bsd
+ */
+#ifndef _OPENSSH_WRAPPER_INCLUDES_H
+#define _OPENSSH_WRAPPER_INCLUDES_H
+
+#include <includes.h>
+
+/*
+ * The includes header indirectly includes the config.h file from the OpenSSH
+ * project which conflicts/overrides HIBA's config.h
+ */
+#undef PACKAGE_BUGREPORT
+#undef PACKAGE_NAME
+#undef PACKAGE_STRING
+#undef PACKAGE_TARNAME
+#undef PACKAGE_URL
+#undef PACKAGE_VERSION
+
+#endif  /* _OPENSSH_WRAPPER_INCLUDES_H */

--- a/revocations.c
+++ b/revocations.c
@@ -12,8 +12,10 @@
 #include <sys/types.h>
 #include <time.h>
 
-#include "errors.h"
+#include "config.h"
+
 #include "log.h"
+#include "errors.h"
 #include "revocations.h"
 
 #define HIBA_CURRENT_GRL_VERSION	0x1

--- a/util.c
+++ b/util.c
@@ -14,8 +14,12 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include "config.h"
+
+#include "certificates.h"
+#include "errors.h"
+#include "extensions.h"
 #include "log.h"
-#include "hiba.h"
 #include "misc.h"
 #include "openbsd-compat/bsd-misc.h"
 #include "ssherr.h"


### PR DESCRIPTION
Create a new openssh/ folder and add a wrapper to OpenSSH includes. This
allows the code to:

* Rely on includes.h from OpenSSH for better compatibility (see
  github.com/google/hiba/commit/642d64ffec5719178644078867bcd4ff88298621).
* Fix pre-processor conflicts on config.h symbols that are used in both
  projects.

This also remove uneeded includes in some source files.